### PR TITLE
docs: Fix docker command in README to not throw error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ you can optionally use volumes to save state:
 ```sh
 # run container in background and persist data (docs, nginx configs)
 # use 'ghcr.io/docat-org/docat:unstable' to get the latest changes
+mkdir -p docat-run/db && touch docat-run/db/db.json
 docker run \
   --detach \
   --volume $PWD/docat-run/doc:/var/docat/doc/ \


### PR DESCRIPTION
Prevent "Is a directory: db.json" error when running the docker command
without previously creating the db.json file. This happens because
docker will create every mount point as a directory if it not exists
previously.

Maybe providing a docker-compose file will be also a good idea for the future :)