### PR TITLE
docs: Adapt URL in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 https://github.com/randombenj/docat
+Copyright (c) 2019 https://github.com/docat-org/docat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Since the repo has moved to a Github organisation