### PR TITLE
Fix docs page to redirect if no version in url

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -54,7 +54,7 @@ import Delete from '@/pages/Delete.vue'
 
 const routes = [
   { path: '/', component: Home },
-  { path: '/:project/:version/:location(.*)?', component: Docs },
+  { path: '/:project/:version?/:location(.*)?', component: Docs },
   { path: '/help', component: Help },
   { path: '/upload', component: Upload },
   { path: '/claim', component: Claim },

--- a/web/src/pages/Docs.vue
+++ b/web/src/pages/Docs.vue
@@ -36,15 +36,11 @@ export default {
     return {
       selectedVersion: this.$route.params.version,
       versions: [],
-      docURL: ProjectRepository.getProjectDocsURL(
-        this.$route.params.project,
-        this.$route.params.version,
-        (this.$route.params.location || '') + (this.$route.hash || '')
-      )
+      docURL: undefined
     }
   },
   beforeRouteUpdate(to, from, next) {
-    if (to.params.version !== from.params.version) {
+    if (to.params.version && to.params.version !== from.params.version) {
       // hard reload iframe only when switching versions
       this.docURL = ProjectRepository.getProjectDocsURL(
         to.params.project,
@@ -58,6 +54,16 @@ export default {
     this.versions = (await ProjectRepository.getVersions(
       this.$route.params.project
     )).map((version) => version.name)
+
+    if (!this.selectedVersion) {
+      this.selectedVersion = (this.versions.find((version) => version == 'latest') || this.versions[0]);
+    }
+
+    this.docURL = ProjectRepository.getProjectDocsURL(
+      this.$route.params.project,
+      this.selectedVersion,
+      (this.$route.params.location || '') + (this.$route.hash || '')
+    )
   },
   methods: {
     onChange() {
@@ -68,8 +74,10 @@ export default {
           a.setAttribute('target', '_blank')
         }
       })
-
-      this.load(docsFrame.contentWindow.location.href)
+      
+      if(this.docURL) {
+        this.load(docsFrame.contentWindow.location.href)
+      }
     },
     load(docPath) {
 


### PR DESCRIPTION
Hi there :)

Just something small I realized when working with docat. Previously, you always had to specify a version in the url like `do.cat/#/my-awesome-doc/latest/`. When using just `do.cat/#/my-awesome-doc/` it showed an empty page. However, it would be much nicer if it would automatically redirect to the latest version in this case. So I tried to fix that with this Pull Request.

Hope you like the way implemented it :)