### PR TITLE
fix(docker) specify strongly base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app/docat
 RUN poetry install --no-root --no-ansi --no-dev
 
 # production
-FROM python:3.9-alpine
+FROM python:3.9.10-alpine3.15
 
 # set up the system
 RUN apk update && \


### PR DESCRIPTION
On my system, the base image had an outdated version of alpine and couldn't access the version 1.20 of nginx (only the old 1.18)
Specifying the version of alpine is always a good idea I believe.