### PR TITLE
Fix order of document viewer route

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -54,11 +54,11 @@ import Delete from '@/pages/Delete.vue'
 
 const routes = [
   { path: '/', component: Home },
-  { path: '/:project/:version?/:location(.*)?', component: Docs },
   { path: '/help', component: Help },
   { path: '/upload', component: Upload },
   { path: '/claim', component: Claim },
   { path: '/delete', component: Delete },
+  { path: '/:project/:version?/:location(.*)?', component: Docs }
 ]
 
 const router = new VueRouter({


### PR DESCRIPTION
This PR fixes #137.

After some testing, I think this should fix the issue.

When I updated the route with my feature I didn't really think carefully about the order of it. Routes with params should be after the static ones if they are on the same level.

Would you prefer having it even split up into two separate routes?
Like this:
```
 { path: '/:project/', component: Docs },
 { path: '/:project/:version/:location(.*)?', component: Docs }
```
Instead of now (with my fix):
```
{ path: '/:project/:version?/:location(.*)?', component: Docs }
```