### PR TITLE
Fix versions selection

### DIFF
--- a/web/src/components/HomeButton.vue
+++ b/web/src/components/HomeButton.vue
@@ -1,0 +1,12 @@
+<template>
+  <md-button to="/" class="md-fab md-primary">
+    <md-icon>home</md-icon>
+    <md-tooltip md-direction="left">Return to home</md-tooltip>
+  </md-button>
+</template>
+
+<script>
+export default {
+  name: 'HomeButton'
+}
+</script>

--- a/web/src/components/VersionsButton.vue
+++ b/web/src/components/VersionsButton.vue
@@ -1,0 +1,44 @@
+<template>
+    <md-menu md-direction="top-start" md-size="big" md-align-trigger>
+        <md-button md-menu-trigger class="md-fab md-primary">
+            <md-icon>menu</md-icon>
+            <md-tooltip md-direction="left">select the version of the project</md-tooltip>
+        </md-button>
+        <md-menu-content>
+            <md-menu-item v-for="version of versions" v-bind:key="version" :href="projectName + '/' + version">{{ version }}</md-menu-item>
+        </md-menu-content>
+    </md-menu>
+</template>
+
+<script>
+import ProjectRepository from '@/repositories/ProjectRepository'
+
+export default {
+  name: 'VersionsButton',
+  data() {
+    return {
+      selectedVersion: this.$route.params.version,
+      versions: [],
+      docURL: undefined,
+      projectName: this.$route.params.project,
+    }
+  },
+  async created() {
+    this.versions = (await ProjectRepository.getVersions(
+      this.$route.params.project
+    )).map((version) => version.name).sort(ProjectRepository.compareVersions)
+
+    if (!this.selectedVersion) {
+      this.selectedVersion = (this.versions.find((version) => version == 'latest') || this.versions[0]);
+    }
+  },
+  methods: {
+  }
+}
+</script>
+
+<style lang="scss">
+.md-menu{
+    margin: 6px 8px;
+}
+</style>

--- a/web/src/components/VersionsButton.vue
+++ b/web/src/components/VersionsButton.vue
@@ -5,7 +5,7 @@
             <md-tooltip md-direction="left">select the version of the project</md-tooltip>
         </md-button>
         <md-menu-content>
-            <md-menu-item v-for="version of versions" v-bind:key="version" :href="projectName + '/' + version">{{ version }}</md-menu-item>
+            <md-menu-item v-for="version of versions" v-bind:key="version" :href="createRedirection(version)" >{{ version }}</md-menu-item>
         </md-menu-content>
     </md-menu>
 </template>
@@ -33,6 +33,14 @@ export default {
     }
   },
   methods: {
+    createRedirection(newVersion) {
+      let docPath = ProjectRepository.getDocsPath(
+          this.$route.params.project,
+          this.selectedVersion,
+          window.location.href
+        )
+      return ProjectRepository.getProjectDocsURL(this.$route.params.project, newVersion, docPath || '', "#")
+    },
   }
 }
 </script>

--- a/web/src/pages/Docs.vue
+++ b/web/src/pages/Docs.vue
@@ -1,41 +1,28 @@
 <template>
   <div class="container">
-    <iframe id="docs" :src="docURL" @load="onChange()"></iframe>
-    <div class="controls">
-      <md-button to="/" class="home-button md-fab md-primary">
-        <md-icon>home</md-icon>
-        <md-tooltip md-direction="left">docs overview</md-tooltip>
-      </md-button>
 
-      <md-field class="version-select">
-        <md-select
-          @md-selected="load()"
-          v-model="selectedVersion"
-          name="version"
-          id="version"
-        >
-          <md-option
-            v-for="version of versions"
-            v-bind:key="version"
-            :value="version"
-          >
-            {{ version }}
-          </md-option>
-        </md-select>
-      </md-field>
-    </div>
+    <iframe id="docs" :src="docURL" @load="onChange()"></iframe>
+
+    <HomeButton class="home-button floating-button"/>
+    <VersionsButton class="versions-button floating-button"/>
+
   </div>
 </template>
 
 <script>
 import ProjectRepository from '@/repositories/ProjectRepository'
+import HomeButton from '@/components/HomeButton.vue'
+import VersionsButton from '@/components/VersionsButton.vue'
 
 export default {
   name: 'docs',
+  components: {
+    HomeButton,
+    VersionsButton,
+  },
   data() {
     return {
       selectedVersion: this.$route.params.version,
-      versions: [],
       docURL: undefined
     }
   },
@@ -51,13 +38,6 @@ export default {
   },
   async created() {
     document.title = this.$route.params.project + " | docat"
-    this.versions = (await ProjectRepository.getVersions(
-      this.$route.params.project
-    )).map((version) => version.name).sort(ProjectRepository.compareVersions)
-
-    if (!this.selectedVersion) {
-      this.selectedVersion = (this.versions.find((version) => version == 'latest') || this.versions[0]);
-    }
 
     this.docURL = ProjectRepository.getProjectDocsURL(
       this.$route.params.project,
@@ -110,46 +90,18 @@ body,
   height: 100%;
 }
 
-.docs-layout {
-  .md-layout,
-  .md-layout-item {
-    height: 100%;
+@media all {
+  .home-button {
+    right: 80px;
+  }
+  .versions-button {
+    right: 16px;
   }
 }
 
-.version-select {
-  width: 200px;
-  float: right;
-  background: white;
-  border-radius: 7px;
-  padding: 9px;
-  margin-bottom: 0px;
-  border: 1px solid rgba(0, 0, 0, 0.42);
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
-}
-
-.md-field {
-  &:after {
-    display: none;
-  }
-}
-
-.controls {
-  position: absolute;
-  bottom: 32px;
-  right: 50px;
-}
-
-.home-button {
-  border-radius: 7px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 0px;
-  margin-right: -1px;
-  height: 52px;
-  margin-top: 4px;
-  box-shadow: none;
-  border: 1px solid rgba(0, 0, 0, 0.42);
+.floating-button {
+  position: fixed;
+  bottom: 16px;
 }
 
 #docs,
@@ -157,38 +109,5 @@ body,
   width: 100%;
   height: 100%;
   border: none;
-}
-
-.md-list-item.md-selected {
-  .md-list-item-text {
-    color: #a2a2a2;
-  }
-}
-
-.md-app-content {
-  padding: 0px;
-  height: 100%;
-}
-
-.docs-claim-button {
-  position: fixed;
-  bottom: 16px;
-}
-
-@media all {
-  .docs-claim-button {
-    right: 80px;
-  }
-}
-
-.docs-delete-button {
-  position: fixed;
-  bottom: 16px;
-}
-
-@media all {
-  .docs-delete-button {
-    right: 16px;
-  }
 }
 </style>

--- a/web/src/pages/Docs.vue
+++ b/web/src/pages/Docs.vue
@@ -28,6 +28,7 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     if (to.params.version && to.params.version !== from.params.version) {
+      this.selectedVersion = to.params.version
       // hard reload iframe only when switching versions
       this.docURL = ProjectRepository.getProjectDocsURL(
         to.params.project,

--- a/web/src/repositories/ProjectRepository.js
+++ b/web/src/repositories/ProjectRepository.js
@@ -3,8 +3,9 @@ const port = process.env.VUE_APP_BACKEND_PORT || location.port
 const host = process.env.VUE_APP_BACKEND_HOST || location.hostname
 const semver = require('semver')
 
-const resource = 'doc'
 export default {
+
+  resource: 'doc',
 
   baseURL: `${location.protocol}//${host}:${port}`,
 
@@ -24,7 +25,7 @@ export default {
    * Returns all projects
    */
   async get() {
-    const resp = await fetch(`${this.baseURL}/${resource}/`)
+    const resp = await fetch(`${this.baseURL}/${this.resource}/`)
     return await resp.json()
   },
 
@@ -33,7 +34,7 @@ export default {
    * @param {string} projectName Name of the project
    */
   getProjectLogoURL(projectName) {
-    return `${this.baseURL}/${resource}/${projectName}/logo.jpg`
+    return `${this.baseURL}/${this.resource}/${projectName}/logo.jpg`
   },
 
   /**
@@ -42,8 +43,8 @@ export default {
    * @param {string} version Version name
    * @param {string?} docsPath Path to the documentation page
    */
-  getProjectDocsURL(projectName, version, docsPath) {
-    return `${this.baseURL}/${resource}/${projectName}/${version}/${docsPath || ''}`
+  getProjectDocsURL(projectName, version, docsPath, resource) {
+    return `${this.baseURL}/${resource || this.resource}/${projectName}/${version}/${docsPath || ''}`
   },
 
   /**
@@ -53,13 +54,15 @@ export default {
    * @param {string} fullDocsPath Full path to the docs including prefix, project and version
    */
   getDocsPath(projectName, version, fullDocsPath) {
+    let escapedProjectName = projectName.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+    let escapedVersion = version.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
     const match = decodeURIComponent(fullDocsPath).match(new RegExp(
-      String.raw`(.*)/${resource}/${projectName}/${version}/(.*)`
+      `(?<=${escapedProjectName}/${escapedVersion}/)(.*)`
     ))
-    if (match && match.length > 2) {
-      return match[2] || ""
+    if (match && match.length > 0) {
+      return match[0] || ""
     } else {
-      return fullDocsPath
+      return ""
     }
   },
 
@@ -69,7 +72,7 @@ export default {
    * @param {string} projectName Name of the project
    */
   async getVersions(projectName) {
-    const resp = await fetch(`${this.baseURL}/${resource}/${projectName}/`)
+    const resp = await fetch(`${this.baseURL}/${this.resource}/${projectName}/`)
     return (await resp.json())
       .filter((version) => version.type == 'directory')
   },

--- a/web/tests/unit/project-repository.spec.js
+++ b/web/tests/unit/project-repository.spec.js
@@ -40,12 +40,23 @@ describe('ProjectRepository', () => {
 
 
   it('correctly get relative docs path', () => {
-    const [project, version, expectedPath] = ['project', '1.0', 'index.html']
-    const absoluteDocsPath = `https://do.cat/doc/${project}/${version}/${expectedPath}`
+    const [project, version, expectedPath] = ['my_project', '0.0.0', 'thing/thing']
+    const absoluteDocsPath = `https://do.cat/#/${project}/${version}/${expectedPath}`
+    const absoluteDocsPathLocal = `http://localhost:8082/#/${project}/${version}/${expectedPath}`
+    const absoluteDocsPathDoc = `https://do.cat/${ProjectRepository.resource}/${project}/${version}/${expectedPath}`
 
-    const relativeDocsPath = ProjectRepository.getDocsPath('project', '1.0', absoluteDocsPath)
+    const relativeDocsPath = ProjectRepository.getDocsPath(project, version, absoluteDocsPath)
+    const relativeDocsPathLocal = ProjectRepository.getDocsPath(project, version, absoluteDocsPathLocal)
+    const relativeDocsPathDoc = ProjectRepository.getDocsPath(project, version, absoluteDocsPathDoc)
+    
+    const [projectB, versionB, expectedPathB] = ['my_project*() char', '0.0.0', 'thing/thing/my_project*() char/0.0.0']
+    const absoluteDocsPathDocB = `https://do.cat/${ProjectRepository.resource}/${projectB}/${versionB}/${expectedPathB}`
+    const relativeDocsPathB = ProjectRepository.getDocsPath(projectB, versionB, absoluteDocsPathDocB)
 
     expect(relativeDocsPath).toEqual(expectedPath)
+    expect(relativeDocsPathLocal).toEqual(expectedPath)
+    expect(relativeDocsPathDoc).toEqual(expectedPath)
+    expect(relativeDocsPathB).toEqual(expectedPathB)
   })
 
 


### PR DESCRIPTION
On UI:
Modified buttons on the docs page to look like the buttons on home page.
Also prevents overlay of the select field with the versions button.

On version switching behavior:
Keeping the doc path when switching between versions. I think you tried to do that but was definitely not working on my system.
I had to change the repository functions. Added some tests ofc.

