### PR TITLE
Allow db.json to be persisted in a custom location

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The simplest way is to build and run the docker container,
 you can optionally use volumes to save state:
 
 ```sh
-# run container in background and persist data (docs, nginx configs)
+# run container in background and persist data (docs, nginx configs and tokens database)
 # use 'ghcr.io/docat-org/docat:unstable' to get the latest changes
 mkdir -p docat-run/db && touch docat-run/db/db.json
 docker run \
@@ -19,6 +19,22 @@ docker run \
   --volume $PWD/docat-run/doc:/var/docat/doc/ \
   --volume $PWD/docat-run/locations:/etc/nginx/locations.d/ \
   --volume $PWD/docat-run/db/db.json:/app/docat/db.json \
+  --publish 8000:80 \
+  ghcr.io/docat-org/docat
+```
+
+*Alternative:* Mount a dedicated directory to host `db.json` :
+
+```sh
+# run container in background and persist data (docs, nginx configs and tokens database)
+# use 'ghcr.io/docat-org/docat:unstable' to get the latest changes
+mkdir -p docat-run/db && touch docat-run/db/db.json
+docker run \
+  --detach \
+  --volume $PWD/docat-run/doc:/var/docat/doc/ \
+  --volume $PWD/docat-run/locations:/etc/nginx/locations.d/ \
+  --volume $PWD/docat-run/db:/var/docat/db/ \
+  --env DOCAT_DB_PATH=/var/docat/db/db.json
   --publish 8000:80 \
   ghcr.io/docat-org/docat
 ```

--- a/docat/docat/app.py
+++ b/docat/docat/app.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from tinydb import Query, TinyDB
 
-from docat.utils import UPLOAD_FOLDER, calculate_token, create_nginx_config, create_symlink, extract_archive, remove_docs
+from docat.utils import DB_PATH, UPLOAD_FOLDER, calculate_token, create_nginx_config, create_symlink, extract_archive, remove_docs
 
 #: Holds the FastAPI application
 app = FastAPI(
@@ -31,7 +31,8 @@ app = FastAPI(
     redoc_url="/api/redoc",
 )
 #: Holds an instance to the TinyDB
-db = TinyDB("db.json")
+DOCAT_DB_PATH = os.getenv("DOCAT_DB_PATH", DB_PATH)
+db = TinyDB(DOCAT_DB_PATH)
 #: Holds the static base path where the uploaded documentation artifacts are stored
 DOCAT_UPLOAD_FOLDER = Path(os.getenv("DOCAT_DOC_PATH", UPLOAD_FOLDER))
 

--- a/docat/docat/utils.py
+++ b/docat/docat/utils.py
@@ -12,6 +12,7 @@ from jinja2 import Template
 
 NGINX_CONFIG_PATH = Path("/etc/nginx/locations.d")
 UPLOAD_FOLDER = Path("/var/docat/doc")
+DB_PATH = "db.json"
 
 
 def create_symlink(source, destination):


### PR DESCRIPTION
Through Environment variable DOCAT_DB_PATH, defaults to "db.json"