### PR TITLE
fix(github-action): run docker push only on main repo

### DIFF
--- a/.github/workflows/docat.yml
+++ b/.github/workflows/docat.yml
@@ -96,7 +96,10 @@ jobs:
           registry: ${{ matrix.registry.name }}
           username: ${{ matrix.registry.org }}
           password: ${{ secrets[matrix.registry.token] }}
+        # Note(Fliiiix): Only login and push on main repo where the secrets are available
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
 
       - name: Publish Image
         run: |
           docker push --all-tags ${{ matrix.registry.name }}/${{ matrix.registry.org }}/docat
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Forks and dependabot do not have access to the required secrets to do this operations.