### PR TITLE
Fix(docat): Upload of file with name of tag

### DIFF
--- a/docat/docat/app.py
+++ b/docat/docat/app.py
@@ -158,13 +158,12 @@ def tag(project: str, version: str, new_tag: str, response: Response):
     destination = DOCAT_UPLOAD_FOLDER / project / new_tag
     source = DOCAT_UPLOAD_FOLDER / project / version
 
+    if not source.exists():
+        response.status_code = status.HTTP_404_NOT_FOUND
+        return ApiResponse(message=f"Version {version} not found")
+
     if create_symlink(version, destination):
-        msg = f"Tag {new_tag} -> {version} successfully created"
-
-        if not source.exists():
-            msg += f", but version {version} does not exist."
-
-        return ApiResponse(message=msg)
+        return ApiResponse(message=f"Tag {new_tag} -> {version} successfully created")
     else:
         response.status_code = status.HTTP_409_CONFLICT
         return ApiResponse(message=f"Tag {new_tag} would overwrite an existing version!")

--- a/docat/docat/app.py
+++ b/docat/docat/app.py
@@ -127,6 +127,11 @@ def upload(
     base_path = project_base_path / version
     target_file = base_path / file.filename
 
+    if base_path.is_symlink():
+        # disallow overwriting of tags (symlinks) with new uploads
+        response.status_code = status.HTTP_409_CONFLICT
+        return ApiResponse(message="Cannot overwrite existing tag with new version.")
+
     if base_path.exists():
         token_status = check_token_for_project(db, docat_api_key, project)
         if token_status.valid:
@@ -151,9 +156,15 @@ def upload(
 @app.put("/api/{project}/{version}/tags/{new_tag}/", response_model=ApiResponse, status_code=status.HTTP_201_CREATED)
 def tag(project: str, version: str, new_tag: str, response: Response):
     destination = DOCAT_UPLOAD_FOLDER / project / new_tag
+    source = DOCAT_UPLOAD_FOLDER / project / version
 
     if create_symlink(version, destination):
-        return ApiResponse(message=f"Tag {new_tag} -> {version} successfully created")
+        msg = f"Tag {new_tag} -> {version} successfully created"
+
+        if not source.exists():
+            msg += f", but version {version} does not exist."
+
+        return ApiResponse(message=msg)
     else:
         response.status_code = status.HTTP_409_CONFLICT
         return ApiResponse(message=f"Tag {new_tag} would overwrite an existing version!")

--- a/docat/tests/test_upload.py
+++ b/docat/tests/test_upload.py
@@ -62,7 +62,7 @@ def test_successful_tag_creation(client_with_claimed_project):
     assert create_tag_response.json() == {"message": "Tag latest -> 1.0.0 successfully created"}
 
 
-def test_warning_on_broken_symlink_creation(client_with_claimed_project):
+def test_create_tag_fails_when_version_does_not_exist(client_with_claimed_project):
     create_project_response = client_with_claimed_project.post(
         "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
     )
@@ -71,10 +71,8 @@ def test_warning_on_broken_symlink_creation(client_with_claimed_project):
 
     create_tag_response = client_with_claimed_project.put("/api/some-project/non-existing-version/tags/new-tag")
 
-    assert create_tag_response.status_code == 201
-    assert create_tag_response.json() == {
-        "message": "Tag new-tag -> non-existing-version successfully created, but version non-existing-version does not exist."
-    }
+    assert create_tag_response.status_code == 404
+    assert create_tag_response.json() == {"message": "Version non-existing-version not found"}
 
 
 def test_create_tag_fails_on_overwrite_of_version(client_with_claimed_project):
@@ -90,7 +88,7 @@ def test_create_tag_fails_on_overwrite_of_version(client_with_claimed_project):
     )
     assert create_project_response.status_code == 201
 
-    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/non-existing-version/tags/{version}")
+    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/{version}/tags/{version}")
     assert create_tag_response.status_code == 409
     assert create_tag_response.json() == {"message": f"Tag {version} would overwrite an existing version!"}
 

--- a/docat/tests/test_upload.py
+++ b/docat/tests/test_upload.py
@@ -1,5 +1,8 @@
 import io
+from pathlib import Path
 from unittest.mock import call, patch
+
+import docat.app as docat
 
 
 def test_successfully_upload(client):
@@ -51,53 +54,64 @@ def test_tags_are_not_overwritten_without_api_key(client_with_claimed_project):
 
 
 def test_successful_tag_creation(client_with_claimed_project):
-    create_project_response = client_with_claimed_project.post(
-        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
-    )
-    assert create_project_response.status_code == 201
+    with patch("docat.app.create_symlink") as create_symlink_mock:
+        create_project_response = client_with_claimed_project.post(
+            "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+        )
+        assert create_project_response.status_code == 201
 
-    create_tag_response = client_with_claimed_project.put("/api/some-project/1.0.0/tags/latest")
+        create_tag_response = client_with_claimed_project.put("/api/some-project/1.0.0/tags/latest")
 
-    assert create_tag_response.status_code == 201
-    assert create_tag_response.json() == {"message": "Tag latest -> 1.0.0 successfully created"}
+        assert create_tag_response.status_code == 201
+        assert create_tag_response.json() == {"message": "Tag latest -> 1.0.0 successfully created"}
+
+        destination_path = docat.DOCAT_UPLOAD_FOLDER / Path("some-project") / Path("latest")
+        assert create_symlink_mock.mock_calls == [call("1.0.0", destination_path), call().__bool__()]
 
 
 def test_create_tag_fails_when_version_does_not_exist(client_with_claimed_project):
-    create_project_response = client_with_claimed_project.post(
-        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
-    )
+    with patch("docat.app.create_symlink") as create_symlink_mock:
+        create_project_response = client_with_claimed_project.post(
+            "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+        )
 
-    assert create_project_response.status_code == 201
+        assert create_project_response.status_code == 201
 
-    create_tag_response = client_with_claimed_project.put("/api/some-project/non-existing-version/tags/new-tag")
+        create_tag_response = client_with_claimed_project.put("/api/some-project/non-existing-version/tags/new-tag")
 
-    assert create_tag_response.status_code == 404
-    assert create_tag_response.json() == {"message": "Version non-existing-version not found"}
+        assert create_tag_response.status_code == 404
+        assert create_tag_response.json() == {"message": "Version non-existing-version not found"}
+
+        assert create_symlink_mock.mock_calls == []
 
 
 def test_create_tag_fails_on_overwrite_of_version(client_with_claimed_project):
     """
     Create a tag with the same name as a version.
     """
-
     project_name = "some-project"
     version = "1.0.0"
+    tag = "latest"
 
-    create_project_response = client_with_claimed_project.post(
+    create_first_project_response = client_with_claimed_project.post(
         f"/api/{project_name}/{version}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
     )
-    assert create_project_response.status_code == 201
+    assert create_first_project_response.status_code == 201
 
-    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/{version}/tags/{version}")
+    create_second_project_response = client_with_claimed_project.post(
+        f"/api/{project_name}/{tag}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_second_project_response.status_code == 201
+
+    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/{version}/tags/{tag}")
     assert create_tag_response.status_code == 409
-    assert create_tag_response.json() == {"message": f"Tag {version} would overwrite an existing version!"}
+    assert create_tag_response.json() == {"message": f"Tag {tag} would overwrite an existing version!"}
 
 
 def test_create_fails_on_overwrite_of_tag(client_with_claimed_project):
     """
     Create a version with the same name as a tag.
     """
-
     project_name = "some-project"
     version = "1.0.0"
     tag = "some-tag"
@@ -134,4 +148,5 @@ def test_fails_with_invalid_token(client_with_claimed_project):
 
         assert response.status_code == 401
         assert response_data["message"] == "Docat-Api-Key token is not valid for some-project"
+
         assert remove_mock.mock_calls == []

--- a/docat/tests/test_upload.py
+++ b/docat/tests/test_upload.py
@@ -50,6 +50,76 @@ def test_tags_are_not_overwritten_without_api_key(client_with_claimed_project):
         assert remove_mock.mock_calls == []
 
 
+def test_successful_tag_creation(client_with_claimed_project):
+    create_project_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_project_response.status_code == 201
+
+    create_tag_response = client_with_claimed_project.put("/api/some-project/1.0.0/tags/latest")
+
+    assert create_tag_response.status_code == 201
+    assert create_tag_response.json() == {"message": "Tag latest -> 1.0.0 successfully created"}
+
+
+def test_warning_on_broken_symlink_creation(client_with_claimed_project):
+    create_project_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+
+    assert create_project_response.status_code == 201
+
+    create_tag_response = client_with_claimed_project.put("/api/some-project/non-existing-version/tags/new-tag")
+
+    assert create_tag_response.status_code == 201
+    assert create_tag_response.json() == {
+        "message": "Tag new-tag -> non-existing-version successfully created, but version non-existing-version does not exist."
+    }
+
+
+def test_create_tag_fails_on_overwrite_of_version(client_with_claimed_project):
+    """
+    Create a tag with the same name as a version.
+    """
+
+    project_name = "some-project"
+    version = "1.0.0"
+
+    create_project_response = client_with_claimed_project.post(
+        f"/api/{project_name}/{version}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_project_response.status_code == 201
+
+    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/non-existing-version/tags/{version}")
+    assert create_tag_response.status_code == 409
+    assert create_tag_response.json() == {"message": f"Tag {version} would overwrite an existing version!"}
+
+
+def test_create_fails_on_overwrite_of_tag(client_with_claimed_project):
+    """
+    Create a version with the same name as a tag.
+    """
+
+    project_name = "some-project"
+    version = "1.0.0"
+    tag = "some-tag"
+
+    create_project_response = client_with_claimed_project.post(
+        f"/api/{project_name}/{version}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_project_response.status_code == 201
+
+    create_tag_response = client_with_claimed_project.put(f"/api/{project_name}/{version}/tags/{tag}")
+    assert create_tag_response.status_code == 201
+    assert create_tag_response.json() == {"message": f"Tag {tag} -> {version} successfully created"}
+
+    create_project_with_name_of_tag_response = client_with_claimed_project.post(
+        f"/api/{project_name}/{tag}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_project_with_name_of_tag_response.status_code == 409
+    assert create_project_with_name_of_tag_response.json() == {"message": "Cannot overwrite existing tag with new version."}
+
+
 def test_fails_with_invalid_token(client_with_claimed_project):
     with patch("docat.app.remove_docs") as remove_mock:
         response = client_with_claimed_project.post(


### PR DESCRIPTION
Uploading a document failed with the same name as a broken (no reference) tag resulted in a 500 status code and a stacktrace. To fix this, we now check if a symlink with the same name as the uploaded version exists, and fail if it does.

Also, it is now impossible to create a tag to a version that doesn't exist.

fixes #124