### PR TITLE
Bugfix/282-project-titles-look-bad

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "node-sass": "^6.0.0",
     "sass-loader": "^10.0.5",
     "semver": "^7.3.7",
+    "v-tooltip": "^2.1.3",
     "vue": "^2.6.10",
     "vue-markdown": "^2.2.4",
     "vuelidate": "^0.7.4"

--- a/web/src/components/Project.vue
+++ b/web/src/components/Project.vue
@@ -7,7 +7,7 @@
           <img :alt="`${project} project logo`" :src="logoURL" @error="() => hideAvatar = true" />
         </md-avatar>
         <div>
-          <div class="md-title">{{ project }}</div>
+          <div class="md-title" v-tooltip="{ content: project, classes: ['tooltip'] }">{{ project }}</div>
           <div class="md-subhead">{{ versions.length }} Versions </div>
         </div>
       </md-card-header>
@@ -24,6 +24,10 @@
 
 <script>
 import ProjectRepository from '@/repositories/ProjectRepository'
+import Vue from 'vue'
+import VTooltip from 'v-tooltip'
+
+Vue.use(VTooltip)
 
 export default {
   name: 'Project',
@@ -78,7 +82,14 @@ export default {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  
+
+}
+
+.tooltip {
+  background-color: rgb(80, 80, 80);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
 }
 
 .star-div {

--- a/web/src/components/Project.vue
+++ b/web/src/components/Project.vue
@@ -6,7 +6,7 @@
         <md-avatar :class="{ hidden: hideAvatar }">
           <img :alt="`${project} project logo`" :src="logoURL" @error="() => hideAvatar = true" />
         </md-avatar>
-        <div class="md-title-container">
+        <div>
           <div class="md-title">{{ project }}</div>
           <div class="md-subhead">{{ versions.length }} Versions </div>
         </div>
@@ -67,15 +67,18 @@ export default {
 }
 
 .md-card-header {
-  float: left;
   padding: 0px;
   padding-left: 16px;
-  display: flex
+  width: calc(100% - 75px);
+  float: left;
 }
 
-.md-title-container{
-  display: flex;
-  flex-direction: column;
+.md-title {
+  font-size: 120% !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  
 }
 
 .star-div {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -917,7 +917,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.12.13", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.8.4":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -8551,6 +8551,11 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 portfinder@^1.0.26:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
@@ -10972,6 +10977,16 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v-tooltip@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.1.3.tgz#281c2015d1e73787f13c8956aa295b8c3a73f261"
+  integrity sha512-xXngyxLQTOx/yUEy50thb8te7Qo4XU6h4LZB6cvEfVd9mnysUxLEoYwGWDdqR+l69liKsy3IPkdYff3J1gAJ5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    lodash "^4.17.21"
+    popper.js "^1.16.1"
+    vue-resize "^1.0.1"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -11103,6 +11118,13 @@ vue-material@^1.0.0-beta-11:
     vue-github-button "^1.2.0"
     vue-github-buttons "^3.1.0"
     vue-toc "0.0.1"
+
+vue-resize@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-1.0.1.tgz#c120bed4e09938771d622614f57dbcf58a5147ee"
+  integrity sha512-z5M7lJs0QluJnaoMFTIeGx6dIkYxOwHThlZDeQnWZBizKblb99GSejPnK37ZbNE/rVwDcYcHY+Io+AxdpY952w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 vue-router@^3.1.3:
   version "3.6.5"


### PR DESCRIPTION
The title is now smaller, and is cropped when it overflows the card. 
I also added a tooltip so people can see the full title of projects with long names.

@fliiiix 
@randombenj 

I welcome suggestions on how we could improve the style of the tooltip.

For now it looks like this:
![Tooltips](https://user-images.githubusercontent.com/79848181/192722309-7958134e-0cdf-4a4d-b28c-6d2f8b91381f.gif)

Fixes: #282 
