### PR TITLE
Fix(web): Claim Token Selection Broken

### DIFF
--- a/web/src/pages/Claim.vue
+++ b/web/src/pages/Claim.vue
@@ -58,7 +58,7 @@ export default {
   },
   async created() {
     document.title = "Claim Token | docat"
-    this.projects = (await ProjectRepository.get()).map((project) => project.name)
+    this.projects = (await ProjectRepository.get())
   },
   validations: {
     form: {


### PR DESCRIPTION
The ProjectRepository get() method was broken, it needlessly tried to map the result.

fixes: #270 