### PR TITLE
Improvement: Integrate logo into projects endpoint

### DIFF
--- a/docat/docat/models.py
+++ b/docat/docat/models.py
@@ -19,6 +19,7 @@ class ClaimResponse(ApiResponse):
 
 class ProjectWithVersionCount(BaseModel):
     name: str
+    logo: bool
     versions: int
 
 

--- a/docat/docat/utils.py
+++ b/docat/docat/utils.py
@@ -131,7 +131,9 @@ def get_all_projects(upload_folder_path: Path) -> Projects:
             if versions < 1:
                 continue
 
-            projects.append(ProjectWithVersionCount(name=str(project.relative_to(upload_folder_path)), versions=versions))
+            project_name = str(project.relative_to(upload_folder_path))
+            project_has_logo = (upload_folder_path / project / "logo").exists()
+            projects.append(ProjectWithVersionCount(name=project_name, logo=project_has_logo, versions=versions))
 
     return Projects(projects=projects)
 

--- a/docat/tests/test_hide_show.py
+++ b/docat/tests/test_hide_show.py
@@ -50,7 +50,7 @@ def test_hide_only_version_not_listed_in_projects(client_with_claimed_project):
     projects_response = client_with_claimed_project.get("/api/projects")
     assert projects_response.status_code == 200
     assert projects_response.json() == {
-        "projects": [{"name": "some-project", "versions": 1}],
+        "projects": [{"name": "some-project", "logo": False, "versions": 1}],
     }
 
     # hide the only version

--- a/docat/tests/test_project.py
+++ b/docat/tests/test_project.py
@@ -15,7 +15,7 @@ def test_project_api(temp_project_version):
         response = client.get("/api/projects")
 
         assert response.ok
-        assert response.json() == {"projects": [{"name": "project", "versions": 1}]}
+        assert response.json() == {"projects": [{"name": "project", "logo": False, "versions": 1}]}
 
 
 def test_project_api_without_any_projects():

--- a/docat/tests/test_upload_icon.py
+++ b/docat/tests/test_upload_icon.py
@@ -141,3 +141,44 @@ def test_icon_upload_fails_no_image(client_with_claimed_project):
         assert upload_response.json() == {"message": "Icon must be an image"}
         assert remove_file_mock.mock_calls == []
         assert copyfileobj_mock.mock_calls == []
+
+
+def test_get_project_recongizes_icon(client_with_claimed_project):
+    """
+    get_projects should return true, if the project has an icon
+    """
+
+    upload_folder_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert upload_folder_response.status_code == 201
+
+    projects_response = client_with_claimed_project.get("/api/projects")
+    assert projects_response.status_code == 200
+    assert projects_response.json() == {
+        "projects": [
+            {
+                "name": "some-project",
+                "logo": False,
+                "versions": 1,
+            }
+        ]
+    }
+
+    upload_response = client_with_claimed_project.post(
+        "/api/some-project/icon",
+        files={"file": ("icon.jpg", io.BytesIO(ONE_PIXEL_PNG), "image/png")},
+    )
+    assert upload_response.status_code == 200
+
+    projects_response = client_with_claimed_project.get("/api/projects")
+    assert projects_response.status_code == 200
+    assert projects_response.json() == {
+        "projects": [
+            {
+                "name": "some-project",
+                "logo": True,
+                "versions": 1,
+            }
+        ]
+    }

--- a/docat/tests/test_utils.py
+++ b/docat/tests/test_utils.py
@@ -108,4 +108,4 @@ def test_get_all_projects_counts_versions_correctly(client_with_claimed_project)
 
     response = client_with_claimed_project.get("/api/projects")
     assert response.status_code == 200
-    assert response.json() == {"projects": [{"name": "some-project", "versions": len(versions)}]}
+    assert response.json() == {"projects": [{"name": "some-project", "logo": False, "versions": len(versions)}]}

--- a/web/src/components/Project.tsx
+++ b/web/src/components/Project.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import ReactTooltip from 'react-tooltip'
 import { Link } from 'react-router-dom'
 import ProjectRepository from '../repositories/ProjectRepository'
@@ -13,44 +13,18 @@ interface Props {
 }
 
 export default function Project(props: Props): JSX.Element {
-  const [logo, setLogo] = useState<Blob | null>(null)
-
-  // try to load image to prevent image flashing
-  useEffect(() => {
-    void (async () => {
-      const logoURL = ProjectRepository.getProjectLogoURL(props.project.name)
-      try {
-        const response = await fetch(logoURL)
-        if (response.status === 200) {
-          const imgData = await response.blob()
-          setLogo(imgData)
-        }
-      } catch (e) {
-        setLogo(null)
-      }
-    })()
-  }, [props.project])
-
   return (
     <div className={styles['project-card']}>
       <ReactTooltip />
       <div className={styles['project-card-header']}>
         <Link to={`/${props.project.name}/latest`}>
-          {logo == null
+          {props.project.logo
             ? (
-            <div
-              className={styles['project-card-title']}
-              data-tip={props.project.name}
-            >
-              {props.project.name}
-            </div>
-              )
-            : (
             <>
               <img
                 className={styles['project-logo']}
-                src={URL.createObjectURL(logo)}
-                alt={`${props.project.name} project Logo`}
+                src={ProjectRepository.getProjectLogoURL(props.project.name)}
+                alt={`${props.project.name} project logo`}
               />
 
               <div
@@ -60,6 +34,14 @@ export default function Project(props: Props): JSX.Element {
                 {props.project.name}
               </div>
             </>
+              )
+            : (
+            <div
+              className={styles['project-card-title']}
+              data-tip={props.project.name}
+            >
+              {props.project.name}
+            </div>
               )}
         </Link>
         <FavoriteStar

--- a/web/src/models/ProjectsResponse.ts
+++ b/web/src/models/ProjectsResponse.ts
@@ -1,5 +1,6 @@
 export interface Project {
   name: string
+  logo: boolean
   versions: number
 }
 


### PR DESCRIPTION
We don't need to check for each project if an icon exists to prevent flickering, because that is now returned with the projects request.

fixes: #375