### PR TITLE
Improvement: Integrate Versions into Projects API

### DIFF
--- a/docat/docat/app.py
+++ b/docat/docat/app.py
@@ -88,10 +88,10 @@ def update_index(index_db: TinyDB = Depends(get_index_db)):
 
 
 @app.get("/api/projects", response_model=Projects, status_code=status.HTTP_200_OK)
-def get_projects():
+def get_projects(include_hidden: bool = False):
     if not DOCAT_UPLOAD_FOLDER.exists():
         return Projects(projects=[])
-    return get_all_projects(DOCAT_UPLOAD_FOLDER)
+    return get_all_projects(DOCAT_UPLOAD_FOLDER, include_hidden)
 
 
 @app.get(
@@ -106,8 +106,8 @@ def get_projects():
     status_code=status.HTTP_200_OK,
     responses={status.HTTP_404_NOT_FOUND: {"model": ApiResponse}},
 )
-def get_project(project):
-    details = get_project_details(DOCAT_UPLOAD_FOLDER, project)
+def get_project(project, include_hidden: bool = False):
+    details = get_project_details(DOCAT_UPLOAD_FOLDER, project, include_hidden)
 
     if not details:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"message": f"Project {project} does not exist"})

--- a/docat/docat/models.py
+++ b/docat/docat/models.py
@@ -17,19 +17,20 @@ class ClaimResponse(ApiResponse):
     token: str
 
 
-class ProjectWithVersionCount(BaseModel):
-    name: str
-    logo: bool
-    versions: int
-
-
-class Projects(BaseModel):
-    projects: list[ProjectWithVersionCount]
-
-
 class ProjectVersion(BaseModel):
     name: str
     tags: list[str]
+    hidden: bool
+
+
+class Project(BaseModel):
+    name: str
+    logo: bool
+    versions: list[ProjectVersion]
+
+
+class Projects(BaseModel):
+    projects: list[Project]
 
 
 class ProjectDetail(BaseModel):

--- a/docat/tests/test_hide_show.py
+++ b/docat/tests/test_hide_show.py
@@ -6,7 +6,7 @@ import docat.app as docat
 
 def test_hide(client_with_claimed_project):
     """
-    Tests that the version is no longer returned when getting the details after hiding
+    Tests that the version is marked as hidden when getting the details after hiding
     """
     # create a version
     create_response = client_with_claimed_project.post(
@@ -19,7 +19,7 @@ def test_hide(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": []}],
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
     }
 
     # hide the version
@@ -50,7 +50,7 @@ def test_hide_only_version_not_listed_in_projects(client_with_claimed_project):
     projects_response = client_with_claimed_project.get("/api/projects")
     assert projects_response.status_code == 200
     assert projects_response.json() == {
-        "projects": [{"name": "some-project", "logo": False, "versions": 1}],
+        "projects": [{"name": "some-project", "logo": False, "versions": [{"name": "1.0.0", "tags": [], "hidden": False}]}],
     }
 
     # hide the only version
@@ -189,7 +189,7 @@ def test_hide_fails_invalid_token(client_with_claimed_project):
 
 def test_show(client_with_claimed_project):
     """
-    Tests that the version is returned again after requesting show.
+    Tests that the version is no longer marked as hidden after requesting show.
     """
     # create a version
     create_response = client_with_claimed_project.post(
@@ -220,7 +220,7 @@ def test_show(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": []}],
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
     }
 
 
@@ -356,7 +356,7 @@ def test_show_fails_invalid_token(client_with_claimed_project):
 
 def test_hide_and_show_with_tag(client_with_claimed_project):
     """
-    Tests that the version is returned again after requesting show on a tag.
+    Tests that the version is no longer marked as hidden after requesting show on a tag.
     """
     # create a version
     create_response = client_with_claimed_project.post(
@@ -392,5 +392,5 @@ def test_hide_and_show_with_tag(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": ["latest"]}],
+        "versions": [{"name": "1.0.0", "tags": ["latest"], "hidden": False}],
     }

--- a/docat/tests/test_project.py
+++ b/docat/tests/test_project.py
@@ -1,10 +1,13 @@
+import io
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from docat.app import app
+import docat.app as docat
+from docat.models import ProjectDetail, ProjectVersion
+from docat.utils import get_project_details
 
-client = TestClient(app)
+client = TestClient(docat.app)
 
 
 def test_project_api(temp_project_version):
@@ -15,7 +18,17 @@ def test_project_api(temp_project_version):
         response = client.get("/api/projects")
 
         assert response.ok
-        assert response.json() == {"projects": [{"name": "project", "logo": False, "versions": 1}]}
+        assert response.json() == {
+            "projects": [
+                {
+                    "name": "project",
+                    "logo": False,
+                    "versions": [
+                        {"name": "1.0", "tags": ["latest"], "hidden": False},
+                    ],
+                }
+            ]
+        }
 
 
 def test_project_api_without_any_projects():
@@ -35,7 +48,7 @@ def test_project_details_api(temp_project_version):
         response = client.get(f"/api/projects/{project}")
 
         assert response.ok
-        assert response.json() == {"name": "project", "versions": [{"name": "1.0", "tags": ["latest"]}]}
+        assert response.json() == {"name": "project", "versions": [{"name": "1.0", "tags": ["latest"], "hidden": False}]}
 
 
 def test_project_details_api_with_a_project_that_does_not_exist():
@@ -43,3 +56,141 @@ def test_project_details_api_with_a_project_that_does_not_exist():
 
     assert not response.ok
     assert response.json() == {"message": "Project i-do-not-exist does not exist"}
+
+
+def test_get_project_details_with_hidden_versions(client_with_claimed_project):
+    """
+    Make sure that get_project_details works when include_hidden is set to True.
+    """
+    # create a version
+    create_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_response.status_code == 201
+
+    # check detected before hiding
+    details = get_project_details(docat.DOCAT_UPLOAD_FOLDER, "some-project", include_hidden=True)
+    assert details == ProjectDetail(name="some-project", versions=[ProjectVersion(name="1.0.0", tags=[], hidden=False)])
+
+    # hide the version
+    hide_response = client_with_claimed_project.post("/api/some-project/1.0.0/hide", headers={"Docat-Api-Key": "1234"})
+    assert hide_response.status_code == 200
+    assert hide_response.json() == {"message": "Version 1.0.0 is now hidden"}
+
+    # check hidden
+    details = get_project_details(docat.DOCAT_UPLOAD_FOLDER, "some-project", include_hidden=True)
+    assert details == ProjectDetail(name="some-project", versions=[ProjectVersion(name="1.0.0", tags=[], hidden=True)])
+
+
+def test_project_details_without_hidden_versions(client_with_claimed_project):
+    """
+    Make sure that project_details works when include_hidden is set to False.
+    """
+    # create a version
+    create_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_response.status_code == 201
+
+    # check detected before hiding
+    details = get_project_details(docat.DOCAT_UPLOAD_FOLDER, "some-project", include_hidden=False)
+    assert details == ProjectDetail(name="some-project", versions=[ProjectVersion(name="1.0.0", tags=[], hidden=False)])
+
+    # hide the version
+    hide_response = client_with_claimed_project.post("/api/some-project/1.0.0/hide", headers={"Docat-Api-Key": "1234"})
+    assert hide_response.status_code == 200
+    assert hide_response.json() == {"message": "Version 1.0.0 is now hidden"}
+
+    # check hidden
+    details = get_project_details(docat.DOCAT_UPLOAD_FOLDER, "some-project", include_hidden=False)
+    assert details == ProjectDetail(name="some-project", versions=[])
+
+
+def test_include_hidden_parameter_for_get_projects(client_with_claimed_project):
+    """
+    Make sure that include_hidden has the desired effect on the /api/projects endpoint.
+    """
+    # create a version
+    create_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_response.status_code == 201
+
+    # check detected before hiding
+    get_projects_response = client_with_claimed_project.get("/api/projects")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "projects": [{"name": "some-project", "logo": False, "versions": [{"name": "1.0.0", "tags": [], "hidden": False}]}]
+    }
+
+    # check include_hidden=True
+    get_projects_response = client_with_claimed_project.get("/api/projects?include_hidden=true")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "projects": [{"name": "some-project", "logo": False, "versions": [{"name": "1.0.0", "tags": [], "hidden": False}]}]
+    }
+
+    # hide the version
+    hide_response = client_with_claimed_project.post("/api/some-project/1.0.0/hide", headers={"Docat-Api-Key": "1234"})
+    assert hide_response.status_code == 200
+    assert hide_response.json() == {"message": "Version 1.0.0 is now hidden"}
+
+    # check include_hidden=False
+    get_projects_response = client_with_claimed_project.get("/api/projects?include_hidden=false")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {"projects": []}
+
+    # check include_hidden=True
+    get_projects_response = client_with_claimed_project.get("/api/projects?include_hidden=true")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "projects": [{"name": "some-project", "logo": False, "versions": [{"name": "1.0.0", "tags": [], "hidden": True}]}]
+    }
+
+
+def test_include_hidden_parameter_for_get_project_details(client_with_claimed_project):
+    """
+    Make sure that include_hidden has the desired effect on the /api/project/{project} endpoint.
+    """
+    # create a version
+    create_response = client_with_claimed_project.post(
+        "/api/some-project/1.0.0", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
+    )
+    assert create_response.status_code == 201
+
+    # check detected before hiding
+    get_projects_response = client_with_claimed_project.get("/api/projects/some-project")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "name": "some-project",
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+    }
+
+    # check include_hidden=True
+    get_projects_response = client_with_claimed_project.get("/api/projects/some-project?include_hidden=true")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "name": "some-project",
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+    }
+
+    # hide the version
+    hide_response = client_with_claimed_project.post("/api/some-project/1.0.0/hide", headers={"Docat-Api-Key": "1234"})
+    assert hide_response.status_code == 200
+    assert hide_response.json() == {"message": "Version 1.0.0 is now hidden"}
+
+    # check include_hidden=False
+    get_projects_response = client_with_claimed_project.get("/api/projects/some-project?include_hidden=false")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "name": "some-project",
+        "versions": [],
+    }
+
+    # check include_hidden=True
+    get_projects_response = client_with_claimed_project.get("/api/projects/some-project?include_hidden=true")
+    assert get_projects_response.status_code == 200
+    assert get_projects_response.json() == {
+        "name": "some-project",
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": True}],
+    }

--- a/docat/tests/test_upload_icon.py
+++ b/docat/tests/test_upload_icon.py
@@ -160,7 +160,7 @@ def test_get_project_recongizes_icon(client_with_claimed_project):
             {
                 "name": "some-project",
                 "logo": False,
-                "versions": 1,
+                "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
             }
         ]
     }
@@ -178,7 +178,7 @@ def test_get_project_recongizes_icon(client_with_claimed_project):
             {
                 "name": "some-project",
                 "logo": True,
-                "versions": 1,
+                "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
             }
         ]
     }

--- a/docat/tests/test_utils.py
+++ b/docat/tests/test_utils.py
@@ -1,4 +1,3 @@
-import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -87,25 +86,3 @@ def test_remove_symlink_version(temp_project_version):
     remove_docs(project, "latest", docat.DOCAT_UPLOAD_FOLDER)
 
     assert not symlink_to_latest.exists()
-
-
-def test_get_all_projects_counts_versions_correctly(client_with_claimed_project):
-    """
-    Tests whether get_all_projects returns the correct number of versions.
-    (Don't count symlinks)
-    """
-
-    versions = ["1.0.0", "2.0.0", "3.0.0"]
-    for version in versions:
-        response = client_with_claimed_project.post(
-            f"/api/some-project/{version}", files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")}
-        )
-        assert response.status_code == 201
-
-    # tag "3.0.0" as latest
-    response = client_with_claimed_project.put(f"/api/some-project/{versions[-1]}/tags/latest")
-    assert response.status_code == 201
-
-    response = client_with_claimed_project.get("/api/projects")
-    assert response.status_code == 200
-    assert response.json() == {"projects": [{"name": "some-project", "logo": False, "versions": len(versions)}]}

--- a/web/src/components/DocumentControlButtons.tsx
+++ b/web/src/components/DocumentControlButtons.tsx
@@ -14,7 +14,7 @@ interface Props {
   onHideUi: () => void
 }
 
-export default function DocumentControlButtons (props: Props): JSX.Element {
+export default function DocumentControlButtons(props: Props): JSX.Element {
   const buttonStyle = { width: '25px', height: '25px' }
 
   return (
@@ -34,11 +34,13 @@ export default function DocumentControlButtons (props: Props): JSX.Element {
           onChange={(e) => props.onVersionChange(e.target.value)}
           value={props.versions.length > 0 ? props.version : ''}
         >
-          {props.versions.map((v) => (
-            <MenuItem key={v.name} value={v.name}>
-              {v.name + (v.tags.length > 0 ? ` (${v.tags.join(', ')})` : '')}
-            </MenuItem>
-          ))}
+          {props.versions
+            .filter((v) => !v.hidden || v.name === props.version)
+            .map((v) => (
+              <MenuItem key={v.name} value={v.name}>
+                {v.name + (v.tags.length > 0 ? ` (${v.tags.join(', ')})` : '')}
+              </MenuItem>
+            ))}
         </Select>
       </FormControl>
       <button

--- a/web/src/components/Project.tsx
+++ b/web/src/components/Project.tsx
@@ -50,9 +50,9 @@ export default function Project(props: Props): JSX.Element {
         />
       </div>
       <div className={styles.subhead}>
-        {props.project.versions === 1
-          ? `${props.project.versions} version`
-          : `${props.project.versions} versions`}
+        {props.project.versions.length === 1
+          ? `${props.project.versions.length} version`
+          : `${props.project.versions.length} versions`}
       </div>
     </div>
   )

--- a/web/src/models/ProjectDetails.ts
+++ b/web/src/models/ProjectDetails.ts
@@ -1,9 +1,11 @@
 export default class ProjectDetails {
   name: string
+  hidden: boolean
   tags: string[]
 
-  constructor (name: string, tags: string[]) {
+  constructor(name: string, tags: string[], hidden: boolean) {
     this.name = name
     this.tags = tags
+    this.hidden = hidden
   }
 }

--- a/web/src/models/ProjectsResponse.ts
+++ b/web/src/models/ProjectsResponse.ts
@@ -1,7 +1,9 @@
+import ProjectDetails from './ProjectDetails'
+
 export interface Project {
   name: string
   logo: boolean
-  versions: number
+  versions: ProjectDetails[]
 }
 
 export default interface ProjectsResponse {

--- a/web/src/pages/Claim.tsx
+++ b/web/src/pages/Claim.tsx
@@ -8,7 +8,7 @@ import { useProjects } from '../data-providers/ProjectDataProvider'
 import ProjectRepository from '../repositories/ProjectRepository'
 
 export default function Claim(): JSX.Element {
-  const { projects, loadingFailed } = useProjects()
+  const { projectsWithHiddenVersions: projects, loadingFailed } = useProjects()
 
   const { showMessage } = useMessageBanner()
   const [project, setProject] = useState<string>('none')

--- a/web/src/pages/Delete.tsx
+++ b/web/src/pages/Delete.tsx
@@ -19,7 +19,7 @@ export default function Delete(): JSX.Element {
   const [project, setProject] = useState<string>('none')
   const [version, setVersion] = useState<string>('none')
   const [token, setToken] = useState<string>('')
-  const { projects, loadingFailed, reload } = useProjects()
+  const { projectsWithHiddenVersions: projects, loadingFailed, reload } = useProjects()
   const [versions, setVersions] = useState<ProjectDetails[]>([])
   const [validation, setValidation] = useState<Validation>({})
 
@@ -31,18 +31,7 @@ export default function Delete(): JSX.Element {
       return
     }
 
-    void (async () => {
-      try {
-        const v = await ProjectRepository.getVersions(project)
-        setVersions(v)
-      } catch (e) {
-        console.error(e)
-        showMessage({
-          type: 'error',
-          text: (e as { message: string }).message
-        })
-      }
-    })()
+    setVersions(projects?.find((p) => p.name === project)?.versions ?? [])
   }, [project])
 
   const validate = (

--- a/web/src/repositories/ProjectRepository.ts
+++ b/web/src/repositories/ProjectRepository.ts
@@ -1,15 +1,27 @@
 import semver from 'semver'
 import ProjectDetails from '../models/ProjectDetails'
+import { Project } from '../models/ProjectsResponse'
 import { ApiSearchResponse } from '../models/SearchResult'
 
 const RESOURCE = 'doc'
+
+function filterHiddenVersions(allProjects: Project[]): Project[] {
+  // create deep-copy first
+  const projects = JSON.parse(JSON.stringify(allProjects)) as Project[]
+
+  projects.forEach(p => {
+    p.versions = p.versions.filter(v => !v.hidden)
+  })
+
+  return projects.filter(p => p.versions.length > 0)
+}
 
 /**
  * Returns a list of all versions of a project.
  * @param {string} projectName Name of the project
  */
 async function getVersions (projectName: string): Promise<ProjectDetails[]> {
-  const res = await fetch(`/api/projects/${projectName}`)
+  const res = await fetch(`/api/projects/${projectName}?include_hidden=true`)
 
   if (!res.ok) {
     console.error((await res.json() as { message: string }).message)
@@ -189,6 +201,7 @@ function setFavorite (projectName: string, shouldBeFavorite: boolean): void {
 
 const exp = {
   getVersions,
+  filterHiddenVersions,
   search,
   getProjectLogoURL,
   getProjectDocsURL,

--- a/web/src/tests/repositories/ProjectRepository.test.ts
+++ b/web/src/tests/repositories/ProjectRepository.test.ts
@@ -3,7 +3,7 @@
 
 import ProjectRepository from '../../repositories/ProjectRepository'
 import ProjectDetails from '../../models/ProjectDetails'
-
+import { Project } from '../../models/ProjectsResponse'
 const mockFetchData = (fetchData: any): void => {
   global.fetch = jest.fn().mockImplementation(async () => await Promise.resolve({
     ok: true,
@@ -30,7 +30,7 @@ describe('get versions', () => {
   test('should return versions', async () => {
     const projectName = 'test'
     const versions = ['1.0.0', '2.0.0']
-    const responseData = versions.map(version => (new ProjectDetails(version, ['tag'])))
+    const responseData = versions.map(version => (new ProjectDetails(version, ['tag'], false)))
 
     mockFetchData({ versions: responseData })
 
@@ -253,5 +253,60 @@ describe('favories', () => {
 
     ProjectRepository.setFavorite(project, false)
     expect(ProjectRepository.isFavorite(project)).toBe(false)
+  })
+})
+
+describe('filterHiddenVersions', () => {
+  test('should remove hidden versions', () => {
+    const shownVersion: ProjectDetails = {
+
+      name: 'v-2',
+      tags: ['stable'],
+      hidden: false
+    }
+
+    const hiddenVersion: ProjectDetails =
+    {
+      name: 'v-1',
+      tags: ['latest'],
+      hidden: true
+    }
+
+    const allProjects: Project[] = [
+      {
+        name: 'test-project-1',
+        versions: [shownVersion, hiddenVersion],
+        logo: false
+      }
+    ]
+
+    const shownProjects: Project[] = [
+      {
+        name: 'test-project-1',
+        versions: [shownVersion],
+        logo: false
+      }
+    ]
+
+    const result = ProjectRepository.filterHiddenVersions(allProjects)
+    expect(result).toStrictEqual(shownProjects)
+  })
+  test('should remove the whole project if no shown versions are present', () => {
+    const allProjects: Project[] = [
+      {
+        name: 'test-project-1',
+        versions: [
+          {
+            name: 'v-1',
+            tags: ['latest'],
+            hidden: true
+          }
+        ],
+        logo: true
+      }
+    ]
+
+    const result = ProjectRepository.filterHiddenVersions(allProjects)
+    expect(result).toStrictEqual([])
   })
 })


### PR DESCRIPTION
Now we don't have to load any data for each project, greatly reducing the number of requests and improving responsiveness.

We now also return hidden versions, but with the property "hidden" to distinguish them in the UI, which fixes a bug where you couldn't look at hidden versions because they weren't found.

fixes: #367