### PR TITLE
Improvement: Parallelize Index Creation

### DIFF
--- a/docat/tests/test_index.py
+++ b/docat/tests/test_index.py
@@ -335,36 +335,12 @@ def test_index_project_non_html(client_with_claimed_project):
         )
 
 
-def test_index_all_projects_uses_temp_database(client_with_claimed_project):
-    """
-    Tests whether index_all_projects uses the tmp-index.json db and swaps it afterwards.
-    (The contents are checked in other tests.)
-    """
-    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json"
-    assert temp_db_path.exists() is False
-
-    create_project_response = client_with_claimed_project.post(
-        "/api/some-project/1.0.0",
-        files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")},
-    )
-    assert create_project_response.status_code == 201
-
-    # create a spy as the tmp-index.json db should still be removed
-    with patch.object(Path, "rename", wraps=temp_db_path.rename) as mock_rename:
-        index_all_projects(docat.DOCAT_UPLOAD_FOLDER, docat.DOCAT_INDEX_PATH)
-
-        mock_rename.assert_called_once_with(docat.DOCAT_INDEX_PATH)
-
-    assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json").exists() is False
-    assert docat.DOCAT_INDEX_PATH.exists() is True
-
-
 def test_index_all_projects_returns_if_temp_index_already_exists(client_with_claimed_project):
     """
-    Tests whether index_all_projects returns if the tmp-index.json db already exists.
+    Tests whether index_all_projects returns if the tmp-index-0.json db already exists.
     """
     docat.DOCAT_UPLOAD_FOLDER.mkdir(parents=True, exist_ok=True)
-    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json"
+    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index-0.json"
 
     assert temp_db_path.exists() is False
     temp_db_path.touch()
@@ -381,9 +357,9 @@ def test_index_all_projects_returns_if_temp_index_already_exists(client_with_cla
 
 def test_index_all_projects_temp_database_removed(client_with_claimed_project):
     """
-    Tests whether index_all_projects removes the tmp-index.json db after it is done.
+    Tests whether index_all_projects removes the tmp-index-0.json db after it is done.
     """
-    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json"
+    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index-0.json"
     assert temp_db_path.exists() is False
 
     create_project_response = client_with_claimed_project.post(
@@ -394,15 +370,15 @@ def test_index_all_projects_temp_database_removed(client_with_claimed_project):
 
     index_all_projects(docat.DOCAT_UPLOAD_FOLDER, docat.DOCAT_INDEX_PATH)
 
-    assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json").exists() is False
+    assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index-0.json").exists() is False
     assert docat.DOCAT_INDEX_PATH.exists() is True
 
 
 def test_index_all_projects_all_tmp_databases_removed_on_exception(client_with_claimed_project):
     """
-    Tests whether the tmp-index.json db is removed even though an exception is raised.
+    Tests whether the tmp-index-0.json db is removed even though an exception is raised.
     """
-    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json"
+    temp_db_path = docat.DOCAT_UPLOAD_FOLDER / "tmp-index-0.json"
     assert temp_db_path.exists() is False
 
     create_project_response = client_with_claimed_project.post(
@@ -427,7 +403,6 @@ def test_index_all_projects_all_tmp_databases_removed_on_exception(client_with_c
         assert mock_rename.called is False
         assert exception_raised is True
 
-    assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json").exists() is False
     assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index-0.json").exists() is False
     assert docat.DOCAT_INDEX_PATH.exists() is True
 

--- a/docat/tests/test_index.py
+++ b/docat/tests/test_index.py
@@ -350,10 +350,10 @@ def test_index_all_projects_uses_temp_database(client_with_claimed_project):
     assert create_project_response.status_code == 201
 
     # create a spy as the tmp-index.json db should still be removed
-    with patch.object(Path, "replace", wraps=temp_db_path.replace) as mock_replace:
+    with patch.object(Path, "rename", wraps=temp_db_path.rename) as mock_rename:
         index_all_projects(docat.DOCAT_UPLOAD_FOLDER, docat.DOCAT_INDEX_PATH)
 
-        mock_replace.assert_called_once_with(docat.DOCAT_INDEX_PATH)
+        mock_rename.assert_called_once_with(docat.DOCAT_INDEX_PATH)
 
     assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json").exists() is False
     assert docat.DOCAT_INDEX_PATH.exists() is True
@@ -414,8 +414,8 @@ def test_index_all_projects_all_tmp_databases_removed_on_exception(client_with_c
     exception_raised = False
 
     with patch("docat.utils.index_projects_in_parallel") as mock_index_projects_in_parallel, patch.object(
-        Path, "replace", wraps=temp_db_path.replace
-    ) as mock_replace:
+        Path, "rename", wraps=temp_db_path.rename
+    ) as mock_rename:
         mock_index_projects_in_parallel.side_effect = Exception("Some exception")
 
         try:
@@ -424,7 +424,7 @@ def test_index_all_projects_all_tmp_databases_removed_on_exception(client_with_c
             # catch the exception, as the test would fail otherwise
             exception_raised = True
 
-        assert mock_replace.called is False
+        assert mock_rename.called is False
         assert exception_raised is True
 
     assert (docat.DOCAT_UPLOAD_FOLDER / "tmp-index.json").exists() is False


### PR DESCRIPTION
Now the indexes are created for each project concurrently and finally combined into 'tmp-index.json', before being moved to 'index.json'.

In my tests with 100 projects with 2 versions each, it cut the indexing time from 3 min 25 sec down to 5 sec (approx. 42x faster)

fixes: #405