### PR TITLE
Fix: Links to Docs page didn't work

### DIFF
--- a/docat/docat/nginx/default
+++ b/docat/docat/nginx/default
@@ -23,5 +23,6 @@ server {
     }
 
     location / {
+        try_files $uri /index.html;
     }
 }

--- a/web/src/components/Project.tsx
+++ b/web/src/components/Project.tsx
@@ -30,7 +30,7 @@ export default function Project (props: Props): JSX.Element {
                   <div
                     className={styles['project-card-title-with-logo']}
                   >
-                    {props.project.name} <span className={styles['project-card-version']}>v{props.project.versions[0].name}</span>
+                    {props.project.name} <span className={styles['project-card-version']}>{ProjectRepository.getLatestVersion(props.project.versions).name}</span>
                   </div>
                 </>
                 )
@@ -38,7 +38,7 @@ export default function Project (props: Props): JSX.Element {
                 <div
                   className={styles['project-card-title']}
                 >
-                  {props.project.name} <span className={styles['project-card-version']}>v{props.project.versions[0].name}</span>
+                  {props.project.name} <span className={styles['project-card-version']}>{ProjectRepository.getLatestVersion(props.project.versions).name}</span>
                 </div>
                 )}
           </Link>

--- a/web/src/components/Project.tsx
+++ b/web/src/components/Project.tsx
@@ -12,12 +12,12 @@ interface Props {
   onFavoriteChanged: () => void
 }
 
-export default function Project(props: Props): JSX.Element {
+export default function Project (props: Props): JSX.Element {
   return (
     <div className={styles['project-card']}>
       <div className={styles['project-card-header']}>
         <Tooltip title={props.project.name} placement="top-start" arrow>
-          <Link to={`/${props.project.name}/latest`}>
+          <Link to={`${props.project.name}/latest`}>
             {props.project.logo
               ? (
                 <>

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -4,189 +4,170 @@
   and we need to use some of it's members, which is unsafe
 */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import DocumentControlButtons from '../components/DocumentControlButtons'
-import { useProjects } from '../data-providers/ProjectDataProvider'
 import ProjectDetails from '../models/ProjectDetails'
 import ProjectRepository from '../repositories/ProjectRepository'
 
-import styles from './../style/pages/Docs.module.css'
 import LoadingPage from './LoadingPage'
 import NotFound from './NotFound'
 
-export default function Docs(): JSX.Element {
+import styles from './../style/pages/Docs.module.css'
+import { uniqueId } from 'lodash'
+
+export default function Docs (): JSX.Element {
   const projectParam = useParams().project ?? ''
   const versionParam = useParams().version ?? 'latest'
   const pageParam = useParams().page ?? 'index.html'
   const hideUiParam = useSearchParams()[0].get('hide-ui') === 'true'
 
-  const [project] = useState<string>(projectParam)
-  const [version, setVersion] = useState<string>(versionParam)
-  const [page, setPage] = useState<string>(pageParam)
-  const [hideUi, setHideUi] = useState<boolean>(hideUiParam)
+  const [project, setProject] = useState<string>('')
+  const [version, setVersion] = useState<string>('')
+  const [page, setPage] = useState<string>('')
+  const [hideUi, setHideUi] = useState<boolean>(false)
+
   const [versions, setVersions] = useState<ProjectDetails[]>([])
   const [loadingFailed, setLoadingFailed] = useState<boolean>(false)
 
-  const { projectsWithHiddenVersions: projects } = useProjects()
   const iFrameRef = useRef(null)
 
   document.title = `${project} | docat`
 
-  if (project === '') {
+  if (projectParam === '') {
     setLoadingFailed(true)
   }
 
-  const updateRoute = useCallback(
-    (
-      project: string,
-      version: string,
-      page: string,
-      hideControls: boolean
-    ): void => {
-      const newState = `/#/${project}/${version}/${page}${
-        hideControls ? '?hide-ui=true' : ''
-      }`
+  const updateURL = (newProject: string, newVersion: string, newPage: string, newHideUi: boolean): void => {
+    const url = `#/${newProject}/${newVersion}/${newPage}${newHideUi ? '?hide-ui=true' : ''}`
 
-      // skip updating the route if the new state is the same as the current one
-      if (window.location.hash === newState.substring(1)) {
-        return
-      }
+    if (project === newProject && version === newVersion && page === newPage && hideUi === newHideUi) {
+      // no change
+      return
+    }
 
-      window.history.pushState({}, '', newState)
-    },
-    []
-  )
+    const oldVersion = version
+    const oldPage = page
 
-  updateRoute(project, version, page, hideUi)
+    setProject(newProject)
+    setVersion(newVersion)
+    setPage(newPage)
+    setHideUi(newHideUi)
+
+    if (oldVersion === 'latest' && newVersion !== 'latest') {
+      // replace the url if 'latest' was updated to the actual version
+      window.history.replaceState(null, '', url)
+      return
+    }
+
+    if (oldPage === '' && newPage !== '') {
+      // replace the url if the page was updated from '' to the actual page
+      window.history.replaceState(null, '', url)
+      return
+    }
+
+    window.history.pushState(null, '', url)
+  }
+
+  const onIFrameLocationChanged = (url: string): void => {
+    url = url.split('/doc/')[1]
+    if (url.length === 0) {
+      // should never happen
+      return
+    }
+
+    const parts = url.split('/')
+    const urlProject = parts[0]
+    const urlVersion = parts[1]
+    const urlPage = parts.slice(2).join('/')
+
+    if (urlProject !== project || urlVersion !== version || urlPage !== page) {
+      updateURL(urlProject, urlVersion, urlPage, hideUi)
+    }
+  }
 
   useEffect(() => {
-    if (project === '' || project === 'none') {
-      setVersions([])
+    if (project === '') {
       return
     }
 
-    if (projects == null || projects.length === 0) {
-      return
-    }
+    void (async (): Promise<void> => {
+      try {
+        let allVersions = await ProjectRepository.getVersions(project)
 
-    try {
-      const matchingProjects = projects.filter((p) => p.name === project)
-
-      if (matchingProjects.length !== 1) {
-        setLoadingFailed(true)
-        return
-      }
-
-      let res = matchingProjects[0].versions
-
-      if (res.length === 0) {
-        setLoadingFailed(true)
-        return
-      }
-
-      res = res.sort((a, b) => ProjectRepository.compareVersions(a, b))
-      setVersions(res)
-
-      if (version !== 'latest') {
-        // custom version -> check if it exists
-        const versionsAndTags = res.map((v) => [v.name, ...v.tags]).flat()
-
-        if (!versionsAndTags.includes(version)) {
-          // version does not exist -> fail
+        if (allVersions.length === 0) {
           setLoadingFailed(true)
-          console.log("Version doesn't exist")
+          return
         }
 
-        return
+        allVersions = allVersions.sort((a, b) => ProjectRepository.compareVersions(a, b))
+        let versionToUse = ''
+
+        if (version === 'latest') {
+          versionToUse = ProjectRepository.getLatestVersion(allVersions).name
+        } else {
+          // custom version -> check if it exists
+          const versionsAndTags = allVersions.map((v) => [v.name, ...v.tags]).flat()
+          if (!versionsAndTags.includes(version)) {
+            // version does not exist -> fail
+            setLoadingFailed(true)
+            console.error("Version doesn't exist")
+            return
+          }
+
+          versionToUse = version
+        }
+
+        updateURL(project, versionToUse, page, hideUi)
+        setVersions(allVersions)
+        setLoadingFailed(false)
+      } catch (e) {
+        console.error(e)
+        setLoadingFailed(true)
+      }
+    })()
+  }, [project])
+
+  useEffect(() => {
+    // set props equal to url params and update the url with the default values if empty
+    setProject(p => {
+      if (p !== '') {
+        return p
       }
 
-      // latest version -> check if there is a latest tag
-      const versionWithLatestTag = res.find((v) =>
-        (v.tags ?? []).includes('latest')
-      )
-
-      // if there is a latest tag, use it,
-      // otherwise use the latest version by sorting
-      const latestVersion =
-        versionWithLatestTag != null
-          ? versionWithLatestTag.name
-          : res[res.length - 1].name
-
-      setVersion(latestVersion)
-      updateRoute(project, latestVersion, page, hideUi)
-    } catch (e) {
-      console.error(e)
-      setLoadingFailed(true)
-    }
-  }, [project, projects, version, page, hideUi, updateRoute])
-
-  const handleVersionChange = (v: string): void => {
-    setVersion(v)
-    updateRoute(project, v, page, hideUi)
-  }
-
-  const handleHideControls = (): void => {
-    updateRoute(project, version, page, true)
-    setHideUi(true)
-  }
-
-  /**
-   * This makes all external links in the iFrame open in a new tab
-   * and updates the page url when the location in the iFrame changes
-   */
-  const onIframeLocationChanged = (): void => {
-    if (iFrameRef?.current == null) {
-      return
-    }
-
-    // update the path in the url
-    // @ts-expect-error - ts does not find the location on the iframe
-    const path: string = iFrameRef.current.contentWindow.location.href as string
-    const page = path.split(`${version}/`)[1]
-
-    if (page == null || page.trim().length < 1) {
-      return
-    }
-
-    setPage(page)
-    updateRoute(project, version, page, hideUi)
-
-    // make all links in iframe open in new tab
-    // @ts-expect-error - ts does not find the document on the iframe
-    iFrameRef.current.contentDocument
-      .querySelectorAll('a')
-      .forEach((a: HTMLAnchorElement) => {
-        if (!a.href.startsWith(window.location.origin)) {
-          a.setAttribute('target', '_blank')
-        }
-      })
-  }
-
-  if (versions == null || versions.length === 0) {
-    return <LoadingPage />
-  }
+      updateURL(projectParam, versionParam, pageParam, hideUiParam)
+      return projectParam
+    })
+  }, [])
 
   if (loadingFailed) {
     return <NotFound />
   }
 
+  if (versions.length === 0) {
+    return <LoadingPage />
+  }
+
   return (
     <>
       <iframe
-        title="docs"
         ref={iFrameRef}
+        key={uniqueId()}
         src={ProjectRepository.getProjectDocsURL(project, version, page)}
-        onLoad={onIframeLocationChanged}
+        title="docs"
         className={styles['docs-iframe']}
-      ></iframe>
+        onLoad={() => {
+          // @ts-expect-error ts can't find contentWindow
+          onIFrameLocationChanged(iFrameRef.current?.contentWindow.location.href as string)
+        }}
+      />
 
       {!hideUi && (
         <DocumentControlButtons
           version={version}
           versions={versions}
-          onVersionChange={handleVersionChange}
-          onHideUi={handleHideControls}
+          onVersionChange={(v) => updateURL(project, v, page, hideUi)}
+          onHideUi={() => updateURL(project, version, page, true)}
         />
       )}
     </>

--- a/web/src/pages/EscapeSlashForDocsPath.tsx
+++ b/web/src/pages/EscapeSlashForDocsPath.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useLocation } from 'react-router-dom'
+import ProjectRepository from '../repositories/ProjectRepository'
 import React from 'react'
 
 /**
@@ -7,17 +8,6 @@ import React from 'react'
  * @returns <Navigate to={newLocation} />
  */
 export default function EscapeSlashForDocsPath (): JSX.Element {
-  const url = useLocation().pathname
-  const endOfVersionIndex = url.split('/', 3).join('/').length
-
-  const projectAndVersion = url.substring(0, endOfVersionIndex)
-  const path = url.substring(endOfVersionIndex + 1).replaceAll('/', '%2F')
-
-  let newUrl = projectAndVersion
-
-  if (path.length > 0) {
-    newUrl = `${newUrl}/${path}`
-  }
-
-  return <Navigate to={newUrl}></Navigate>
+  const location = useLocation()
+  return <Navigate to={ProjectRepository.escapeSlashesInUrl(location.pathname, location.search, location.hash)}></Navigate>
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import ProjectRepository from '../repositories/ProjectRepository'
 import { useProjects } from '../data-providers/ProjectDataProvider'
@@ -15,13 +15,27 @@ import LoadingPage from './LoadingPage'
 import styles from './../style/pages/Home.module.css'
 import { ErrorOutline } from '@mui/icons-material'
 import { Project } from '../models/ProjectsResponse'
+import { useLocation } from 'react-router'
 
 export default function Home (): JSX.Element {
   const { projects, loadingFailed } = useProjects()
   const [nonFavoriteProjects, setNonFavoriteProjects] = useState<Project[]>([])
   const [favoriteProjects, setFavoriteProjects] = useState<Project[]>([])
 
+  const location = useLocation()
+
   document.title = 'Home | docat'
+
+  // insert # into the url if it's missing
+  useEffect(() => {
+    const nonHostPart = window.location.href.replace(window.location.origin, '')
+
+    if (nonHostPart.startsWith('#') || nonHostPart.startsWith('/#')) {
+      return
+    }
+
+    window.location.replace(`/#${nonHostPart}`)
+  }, [location])
 
   const updateFavorites = (): void => {
     if (projects == null) return

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -14,7 +14,7 @@ const NO_RESULTS: SearchResult = {
 }
 const debounceMs = 600
 
-export default function Search(): JSX.Element {
+export default function Search (): JSX.Element {
   const queryParam = useSearchParams()[0].get('query') ?? ''
 
   const { projects, loadingFailed } = useProjects()
@@ -47,7 +47,9 @@ export default function Search(): JSX.Element {
 
   useEffect(() => {
     searchDebounced.cancel()
-    window.history.pushState({}, '', `/#/search?query=${searchQuery}`)
+    if (window.location.hash !== `#/search?query=${searchQuery}`) {
+      window.history.pushState({}, '', `/#/search?query=${searchQuery}`)
+    }
     searchDebounced()
   }, [searchQuery, projects, loadingFailed])
 
@@ -69,10 +71,10 @@ export default function Search(): JSX.Element {
       />
       {results === null
         ? (
-        <div className="loading-spinner" />
+          <div className="loading-spinner" />
           )
         : (
-        <SearchResults searchQuery={searchQuery} results={results} />
+          <SearchResults searchQuery={searchQuery} results={results} />
           )}
     </PageLayout>
   )

--- a/web/src/repositories/ProjectRepository.ts
+++ b/web/src/repositories/ProjectRepository.ts
@@ -6,6 +6,30 @@ import { ProjectSearchResult, SearchResult, VersionSearchResult } from '../model
 
 const RESOURCE = 'doc'
 
+/**
+ * Escapes all slashes in a url to the docs page from the point between the version and the path.
+ * This is necessary because react-router thinks that the slashes are path separators.
+ * The slashes are escaped to %2F and reverted back to slashes by react-router.
+ * Example:
+ *  /doc/project/1.0.0/path/to/page -> /doc/project/1.0.0/path%2Fto%2Fpage
+ * @param pathname useLocation().pathname
+ * @param search useLocation().search
+ * @param hash useLocation().hash
+ * @returns a url with escaped slashes
+ */
+function escapeSlashesInUrl (pathname: string, search: string, hash: string): string {
+  const url = pathname + hash + search
+  const projectAndVersion = url.split('/', 3).join('/')
+  let path = url.substring(projectAndVersion.length + 1)
+  path = path.replaceAll('/', '%2F')
+
+  if (path.length === 0) {
+    return projectAndVersion
+  }
+
+  return projectAndVersion + '/' + path
+}
+
 function filterHiddenVersions (allProjects: Project[]): Project[] {
   // create deep-copy first
   const projects = JSON.parse(JSON.stringify(allProjects)) as Project[]
@@ -128,9 +152,10 @@ function getProjectLogoURL (projectName: string): string {
  * @param {string} projectName Name of the project
  * @param {string} version Version name
  * @param {string?} docsPath Path to the documentation page
+ * @param {string?} hash Hash part of the url (html id)
  */
-function getProjectDocsURL (projectName: string, version: string, docsPath?: string): string {
-  return `/${RESOURCE}/${projectName}/${version}/${docsPath ?? ''}`
+function getProjectDocsURL (projectName: string, version: string, docsPath?: string, hash?: string): string {
+  return `/${RESOURCE}/${projectName}/${version}/${docsPath ?? ''}${hash ?? ''}`
 }
 
 /**
@@ -260,6 +285,7 @@ function setFavorite (projectName: string, shouldBeFavorite: boolean): void {
 }
 
 const exp = {
+  escapeSlashesInUrl,
   getVersions,
   getLatestVersion,
   filterHiddenVersions,

--- a/web/src/repositories/ProjectRepository.ts
+++ b/web/src/repositories/ProjectRepository.ts
@@ -37,6 +37,28 @@ async function getVersions (projectName: string): Promise<ProjectDetails[]> {
 }
 
 /**
+ * Returns the latest version of a project.
+ * Order of precedence: latest, latest tag, latest version
+ * @param versions all versions of a project
+ */
+function getLatestVersion (versions: ProjectDetails[]): ProjectDetails {
+  const latest = versions.find((v) => v.name.includes('latest'))
+  if (latest != null) {
+    return latest
+  }
+
+  const latestTag = versions.find((v) => v.tags.includes('latest'))
+  if (latestTag != null) {
+    return latestTag
+  }
+
+  const sortedVersions = versions
+    .sort((a, b) => compareVersions(a, b))
+
+  return sortedVersions[sortedVersions.length - 1]
+}
+
+/**
  * Returns a SearchResult object containing all projects and versions that contain the search query in their name or tag
  * @param {Project[]} projects List of all projects
  * @param {string} searchQuery Search query
@@ -239,6 +261,7 @@ function setFavorite (projectName: string, shouldBeFavorite: boolean): void {
 
 const exp = {
   getVersions,
+  getLatestVersion,
   filterHiddenVersions,
   search,
   getProjectLogoURL,

--- a/web/src/tests/repositories/ProjectRepository.test.ts
+++ b/web/src/tests/repositories/ProjectRepository.test.ts
@@ -532,3 +532,50 @@ describe('getLatestVersion', () => {
     expect(latestVersion).toStrictEqual(versions[0])
   })
 })
+
+describe('escapeSlashesInUrl', () => {
+  test('should ignore version and project name', () => {
+    const url = '/project/1.0.0'
+
+    expect(ProjectRepository.escapeSlashesInUrl(url, '', '')).toBe(url)
+  })
+
+  test('should ignore trailing slash', () => {
+    const given = '/project/1.0.0/'
+    const expected = '/project/1.0.0'
+
+    expect(ProjectRepository.escapeSlashesInUrl(given, '', '')).toBe(expected)
+  })
+
+  test('should escape slashes in path', () => {
+    const given = '/project/1.0.0/path/with/slashes'
+    const expected = '/project/1.0.0/path%2Fwith%2Fslashes'
+
+    expect(ProjectRepository.escapeSlashesInUrl(given, '', '')).toBe(expected)
+  })
+
+  test('should work with query parameters', () => {
+    const given = '/project/1.0.0/path/with/slashes'
+    const query = '?param=value'
+    const expected = '/project/1.0.0/path%2Fwith%2Fslashes?param=value'
+
+    expect(ProjectRepository.escapeSlashesInUrl(given, query, '')).toBe(expected)
+  })
+
+  test('should work with hash', () => {
+    const given = '/project/1.0.0/path/with/slashes'
+    const hash = '#hash'
+    const expected = '/project/1.0.0/path%2Fwith%2Fslashes#hash'
+
+    expect(ProjectRepository.escapeSlashesInUrl(given, '', hash)).toBe(expected)
+  })
+
+  test('should work with query parameters and hash', () => {
+    const given = '/project/1.0.0/path/with/slashes'
+    const query = '?param=value'
+    const hash = '#hash'
+    const expected = '/project/1.0.0/path%2Fwith%2Fslashes#hash?param=value'
+
+    expect(ProjectRepository.escapeSlashesInUrl(given, query, hash)).toBe(expected)
+  })
+})

--- a/web/src/tests/repositories/ProjectRepository.test.ts
+++ b/web/src/tests/repositories/ProjectRepository.test.ts
@@ -460,3 +460,75 @@ describe('filterHiddenVersions', () => {
     expect(result).toStrictEqual([])
   })
 })
+
+describe('getLatestVersion', () => {
+  test('should return latest version by name', () => {
+    const versions: ProjectDetails[] = [
+      {
+        name: '1.0.0',
+        hidden: false,
+        tags: []
+      },
+      {
+        name: '2.0.0',
+        hidden: false,
+        tags: []
+      }
+    ]
+
+    const latestVersion = ProjectRepository.getLatestVersion(versions)
+    expect(latestVersion).toStrictEqual(versions[1])
+  })
+
+  test('should return version with latest in name', () => {
+    const versions: ProjectDetails[] = [
+      {
+        name: '1.0.0',
+        hidden: false,
+        tags: []
+      },
+      {
+        name: 'latest',
+        hidden: false,
+        tags: []
+      }]
+
+    const latestVersion = ProjectRepository.getLatestVersion(versions)
+    expect(latestVersion).toStrictEqual(versions[1])
+  })
+
+  test('should return version with latest tag', () => {
+    const versions: ProjectDetails[] = [
+      {
+        name: '1.0.0',
+        hidden: false,
+        tags: ['latest']
+      },
+      {
+        name: '2.0.0',
+        hidden: false,
+        tags: []
+      }]
+
+    const latestVersion = ProjectRepository.getLatestVersion(versions)
+    expect(latestVersion).toStrictEqual(versions[0])
+  })
+
+  test('should prefer version with latest in name over latest tag', () => {
+    const versions: ProjectDetails[] = [
+      {
+        name: 'latest',
+        hidden: false,
+        tags: []
+      },
+      {
+        name: '1.0.0',
+        hidden: false,
+        tags: ['latest']
+      }
+    ]
+
+    const latestVersion = ProjectRepository.getLatestVersion(versions)
+    expect(latestVersion).toStrictEqual(versions[0])
+  })
+})


### PR DESCRIPTION
The docs page was way too complicated anyway, so I simplified it a bit.

I fixed the following issues:
* Link to docs page resulted in 404, when reloaded
* Browser Back button not working properly (Docs and Search)
* Open in New Tab not working 

fixes: #475, #476, #477, #479