### PR TITLE
fix: docatl tag command within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Same thing with `docatl`:
 
 ```sh
 # tag the version VERSION of project PROJECT as latest
-docatl tag --host http://localhost:8000 PROJECT VERSION
+docatl tag --host http://localhost:8000 PROJECT VERSION latest
 ```
 
 ## Advanced `config.json`


### PR DESCRIPTION
The tag’s value was missing within the README.md for the docatl command.