### PR TITLE
Draft: Add 'upload_date' field to ProjectVersion

### DIFF
--- a/docat/docat/models.py
+++ b/docat/docat/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from pydantic import BaseModel
 
@@ -21,6 +22,7 @@ class ProjectVersion(BaseModel):
     name: str
     tags: list[str]
     hidden: bool
+    upload_date: datetime
 
 
 class Project(BaseModel):

--- a/docat/docat/utils.py
+++ b/docat/docat/utils.py
@@ -4,6 +4,7 @@ docat utilities
 import hashlib
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -129,6 +130,10 @@ def get_all_projects(upload_folder_path: Path, include_hidden: bool) -> Projects
     return Projects(projects=projects)
 
 
+def get_upload_date(docs_folder: Path):
+    return datetime.fromtimestamp(docs_folder.stat().st_mtime)
+
+
 def get_project_details(upload_folder_path: Path, project_name: str, include_hidden: bool) -> ProjectDetail | None:
     """
     Returns all versions and tags for a project.
@@ -154,6 +159,7 @@ def get_project_details(upload_folder_path: Path, project_name: str, include_hid
                     name=str(x.relative_to(docs_folder)),
                     tags=[str(t.relative_to(docs_folder)) for t in tags if t.resolve() == x],
                     hidden=(docs_folder / x.name / ".hidden").exists(),
+                    upload_date=get_upload_date(docs_folder),
                 )
                 for x in docs_folder.iterdir()
                 if x.is_dir() and not x.is_symlink() and should_include(x.name)

--- a/docat/tests/conftest.py
+++ b/docat/tests/conftest.py
@@ -1,5 +1,7 @@
 import tempfile
+from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -7,6 +9,11 @@ from tinydb import TinyDB
 
 import docat.app as docat
 from docat.utils import create_symlink
+
+MOCK_TIMESTAMP_VALUE = 1688437938
+MOCK_TIMESTAMP_DATETIME = datetime.fromtimestamp(MOCK_TIMESTAMP_VALUE)
+MOCK_TIMESTAMP_ISO = datetime.fromtimestamp(MOCK_TIMESTAMP_VALUE).isoformat()
+mock_get_upload_date = MagicMock(return_value=MOCK_TIMESTAMP_DATETIME)
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +46,9 @@ def client_with_claimed_project(client):
     table = docat.db.table("claims")
     token_hash_1234 = b"\xe0\x8cS\xa3)\xb4\xb5\xa5\xda\xc3K\x96\xf6).\xdd-\xacR\x8e3Q\x17\x87\xfb\x94\x0c-\xc2h\x1c\xf3"
     table.insert({"name": "some-project", "token": token_hash_1234.hex(), "salt": ""})
-    yield client
+
+    with patch("docat.utils.get_upload_date", mock_get_upload_date):
+        yield client
 
 
 @pytest.fixture
@@ -53,4 +62,5 @@ def temp_project_version():
 
         return docat.DOCAT_UPLOAD_FOLDER
 
-    yield __create
+    with patch("docat.utils.get_upload_date", mock_get_upload_date):
+        yield __create

--- a/docat/tests/test_hide_show.py
+++ b/docat/tests/test_hide_show.py
@@ -2,6 +2,7 @@ import io
 from unittest.mock import patch
 
 import docat.app as docat
+from tests.conftest import MOCK_TIMESTAMP_ISO
 
 
 def test_hide(client_with_claimed_project):
@@ -19,7 +20,7 @@ def test_hide(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
     }
 
     # hide the version
@@ -50,7 +51,13 @@ def test_hide_only_version_not_listed_in_projects(client_with_claimed_project):
     projects_response = client_with_claimed_project.get("/api/projects")
     assert projects_response.status_code == 200
     assert projects_response.json() == {
-        "projects": [{"name": "some-project", "logo": False, "versions": [{"name": "1.0.0", "tags": [], "hidden": False}]}],
+        "projects": [
+            {
+                "name": "some-project",
+                "logo": False,
+                "versions": [{"name": "1.0.0", "tags": [], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
+            }
+        ],
     }
 
     # hide the only version
@@ -219,7 +226,7 @@ def test_show(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+        "versions": [{"name": "1.0.0", "tags": [], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
     }
 
 
@@ -391,5 +398,5 @@ def test_hide_and_show_with_tag(client_with_claimed_project):
     assert project_details_response.status_code == 200
     assert project_details_response.json() == {
         "name": "some-project",
-        "versions": [{"name": "1.0.0", "tags": ["latest"], "hidden": False}],
+        "versions": [{"name": "1.0.0", "tags": ["latest"], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
     }

--- a/docat/tests/test_upload_icon.py
+++ b/docat/tests/test_upload_icon.py
@@ -3,6 +3,7 @@ import io
 from unittest.mock import call, patch
 
 import docat.app as docat
+from tests.conftest import MOCK_TIMESTAMP_ISO
 
 ONE_PIXEL_PNG = base64.decodebytes(
     b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjYGBg+A8AAQQBAHAgZQsAAAAASUVORK5CYII="
@@ -160,7 +161,7 @@ def test_get_project_recongizes_icon(client_with_claimed_project):
             {
                 "name": "some-project",
                 "logo": False,
-                "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+                "versions": [{"name": "1.0.0", "tags": [], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
             }
         ]
     }
@@ -178,7 +179,7 @@ def test_get_project_recongizes_icon(client_with_claimed_project):
             {
                 "name": "some-project",
                 "logo": True,
-                "versions": [{"name": "1.0.0", "tags": [], "hidden": False}],
+                "versions": [{"name": "1.0.0", "tags": [], "hidden": False, "upload_date": MOCK_TIMESTAMP_ISO}],
             }
         ]
     }

--- a/web/src/components/DocumentControlButtons.tsx
+++ b/web/src/components/DocumentControlButtons.tsx
@@ -13,7 +13,7 @@ interface Props {
   onHideUi: () => void
 }
 
-export default function DocumentControlButtons (props: Props): JSX.Element {
+export default function DocumentControlButtons(props: Props): JSX.Element {
   const buttonStyle = { width: '25px', height: '25px' }
 
   return (
@@ -37,7 +37,7 @@ export default function DocumentControlButtons (props: Props): JSX.Element {
             .filter((v) => !v.hidden || v.name === props.version)
             .map((v) => (
               <MenuItem key={v.name} value={v.name}>
-                {v.name + (v.tags.length > 0 ? ` (${v.tags.join(', ')})` : '')}
+                {v.name + ` (${v.upload_date.toLocaleString()}) ` + (v.tags.length > 0 ? ` (${v.tags.join(', ')})` : '')}
               </MenuItem>
             ))}
         </Select>

--- a/web/src/components/Project.tsx
+++ b/web/src/components/Project.tsx
@@ -12,7 +12,7 @@ interface Props {
   onFavoriteChanged: () => void
 }
 
-export default function Project (props: Props): JSX.Element {
+export default function Project(props: Props): JSX.Element {
   return (
     <div className={styles['project-card']}>
       <div className={styles['project-card-header']}>
@@ -33,14 +33,14 @@ export default function Project (props: Props): JSX.Element {
                     {props.project.name} <span className={styles['project-card-version']}>{ProjectRepository.getLatestVersion(props.project.versions).name}</span>
                   </div>
                 </>
-                )
+              )
               : (
                 <div
                   className={styles['project-card-title']}
                 >
                   {props.project.name} <span className={styles['project-card-version']}>{ProjectRepository.getLatestVersion(props.project.versions).name}</span>
                 </div>
-                )}
+              )}
           </Link>
         </Tooltip>
         <FavoriteStar
@@ -53,6 +53,11 @@ export default function Project (props: Props): JSX.Element {
           ? `${props.project.versions.length} version`
           : `${props.project.versions.length} versions`}
       </div>
+
+      <div className={styles.subhead}>
+        Updated: {new Date(ProjectRepository.getLatestVersion(props.project.versions).upload_date).toLocaleString()}
+      </div>
+
     </div>
   )
 }

--- a/web/src/models/ProjectDetails.ts
+++ b/web/src/models/ProjectDetails.ts
@@ -1,11 +1,13 @@
 export default class ProjectDetails {
   name: string
   hidden: boolean
+  upload_date: Date
   tags: string[]
 
-  constructor(name: string, tags: string[], hidden: boolean) {
+  constructor(name: string, tags: string[], hidden: boolean, upload_date: string) {
     this.name = name
     this.tags = tags
     this.hidden = hidden
+    this.upload_date = new Date(upload_date) // new Date(Date.parse(upload_date))
   }
 }

--- a/web/src/tests/repositories/ProjectRepository.test.ts
+++ b/web/src/tests/repositories/ProjectRepository.test.ts
@@ -30,7 +30,7 @@ describe('get versions', () => {
   test('should return versions', async () => {
     const projectName = 'test'
     const versions = ['1.0.0', '2.0.0']
-    const responseData = versions.map(version => (new ProjectDetails(version, ['tag'], false)))
+    const responseData = versions.map(version => (new ProjectDetails(version, ['tag'], false, "2023-08-07T23:00:59.607Z")))
 
     mockFetchData({ versions: responseData })
 
@@ -271,14 +271,16 @@ describe('filterHiddenVersions', () => {
 
       name: 'v-2',
       tags: ['stable'],
-      hidden: false
+      hidden: false,
+      upload_date: new Date(0)
     }
 
     const hiddenVersion: ProjectDetails =
     {
       name: 'v-1',
       tags: ['latest'],
-      hidden: true
+      hidden: true,
+      upload_date: new Date(0)
     }
 
     const allProjects: Project[] = [
@@ -308,7 +310,8 @@ describe('filterHiddenVersions', () => {
           {
             name: 'v-1',
             tags: ['latest'],
-            hidden: true
+            hidden: true,
+            upload_date: new Date(0)
           }
         ],
         logo: true
@@ -326,12 +329,14 @@ describe('getLatestVersion', () => {
       {
         name: '1.0.0',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       },
       {
         name: '2.0.0',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       }
     ]
 
@@ -344,12 +349,14 @@ describe('getLatestVersion', () => {
       {
         name: '1.0.0',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       },
       {
         name: 'latest',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       }]
 
     const latestVersion = ProjectRepository.getLatestVersion(versions)
@@ -361,12 +368,14 @@ describe('getLatestVersion', () => {
       {
         name: '1.0.0',
         hidden: false,
-        tags: ['latest']
+        tags: ['latest'],
+        upload_date: new Date(0)
       },
       {
         name: '2.0.0',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       }]
 
     const latestVersion = ProjectRepository.getLatestVersion(versions)
@@ -378,12 +387,14 @@ describe('getLatestVersion', () => {
       {
         name: 'latest',
         hidden: false,
-        tags: []
+        tags: [],
+        upload_date: new Date(0)
       },
       {
         name: '1.0.0',
         hidden: false,
-        tags: ['latest']
+        tags: ['latest'],
+        upload_date: new Date(0)
       }
     ]
 


### PR DESCRIPTION
# ⚠️ This MR is currently a draft ⚠️

Hello!

First of all, thank you for developing Docat! It's a simple and self-hosted solution which just works :)

This MR adds a field `upload_date` to the `ProjectVersion` model. The upload date will be visible in Docat's UI when browsing available project versions.

## Progress

- [x] add `upload_date` to the `ProjectVersion` model
- [ ] unit test the backend code ~~(I'm using [this approach](https://www.peterbe.com/plog/mocking-os.stat-in-python) to mock `Path.stat` results) `4 failed / 53 passed`~~ **update:** all UTs are passing, IMO there's no point in unit-testing the new backend code which gets the project upload timestamp, as it boils down to testing python's standard library
- [ ] display the `upload_date` in the UI (**Update:** working out how Typescript/Javascript handle date parsing)

---

Please let me know if you're interested in such a feature :)

**Update:** my way of mocking `Path.stat` breaks `Path.is_symlink` for reasons I do not yet understand. Working on a simpler way of mocking the `upload_date` which will not involve patching stdlib