### PR TITLE
Fix nginx index option url routing

### DIFF
--- a/docat/docat/nginx/default
+++ b/docat/docat/nginx/default
@@ -8,8 +8,7 @@ server {
 
     root /var/www/html;
 
-    # Add index.php to the list if you are using PHP
-    index index.html index.htm index.nginx-debian.html;
+    index index.html index.htm index.pdf /index.html;
 
     server_name _;
 
@@ -23,6 +22,6 @@ server {
     }
 
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ =404;
     }
 }


### PR DESCRIPTION
I think we should use the index instead of just assuming `/index.html`.
@reglim or was there a good reason to not use index?