### PR TITLE
Fix empty links interpreted as not empty, resulted in weird behavior

### DIFF
--- a/web/src/components/IFrame.tsx
+++ b/web/src/components/IFrame.tsx
@@ -37,9 +37,10 @@ export default function IFrame(props: Props): JSX.Element {
           return
         }
 
-        if (a.href.trim() === '') {
-          // ignore empty links, may be handled with js internally,
-          // so we'll ignore it. Will inevitably cause the user to have to click back
+        const href = a.getAttribute('href') ?? ''
+        if (href.trim() === '') {
+          // ignore empty links, may be handled with js internally.
+          // Will inevitably cause the user to have to click back
           // multiple times to get back to the previous page.
           return
         }


### PR DESCRIPTION
Some links like this caused problems:
```<a href="" />```

This was because a.href returned `(page)/index.html`, while I'd expected that to return an empty string. To fix this, I just switched to using `a.getAttribute('href')` which returns the literal value of the link as defined in the html.