### PR TITLE
Fix: Optimize Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # building frontend
-FROM node:20.5 as frontend
+FROM node:20-slim as frontend
 WORKDIR /app/frontend
-COPY web ./
+
+COPY web/package.json web/yarn.lock ./
+RUN yarn install --frozen-lockfile
 
 # fix docker not following symlinks
+COPY web ./
 COPY doc/getting-started.md ./src/assets/
-
-RUN yarn install --frozen-lockfile
 RUN yarn build
 
 # setup Python


### PR DESCRIPTION
I switched from using node:20.5 to node:20-slim, saving a lot of bandwidth when it has to be pulled. I also moved the yarn install up so it only installs the dependencies when the package.json or yarn.lock files changed.

Cuts build time about 15s when developing in frontend. 

fixes: #639