### PR TITLE
feat(backend): Allow project auto-claim with pre-defined token

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -77,6 +77,11 @@ Using `docatl`:
 docatl claim awesome-project --host http://localhost:8000
 ```
 
+In addition, it is possible to claim all projects with a token previously defined via environment variables
+instead of generating a new token for each project. This is particularly useful for CI/CD applications where the
+documentation is automatically uploaded by a build server. This feature needs to be enabled in the backend. You can
+read more about this feature in the [backend documentation](../docat/README.md).
+
 #### Authentication
 
 To make an authenticated call, specify a header with the key `Docat-Api-Key` and your token as the value:

--- a/docat/README.md
+++ b/docat/README.md
@@ -21,6 +21,8 @@ poetry install
 * **DOCAT_SERVE_FILES**: Serve static documentation instead of a nginx (for testing)
 * **DOCAT_STORAGE_PATH**: Upload directory for static files (needs to match nginx config)
 * **FLASK_DEBUG**: Start flask in debug mode
+* **DOCAT_GLOBAL_CLAIM_TOKEN**: If set, all uploaded projects are being claimed automatically with that token.
+* **DOCAT_GLOBAL_CLAIM_SALT**: If set, all claims will be made with this salt.
 
 ## Usage
 

--- a/docat/docat/app.py
+++ b/docat/docat/app.py
@@ -245,9 +245,9 @@ def upload(
     extract_archive(target_file, base_path)
     index_file_exists = (base_path / "index.html").exists()
 
-    token: Optional[str] = None
-    if global_claim_token is not None:
-        token = claim_project(project=project, db=db)
+    token: Optional[str] = global_claim_token or docat_api_key
+    if token is not None:
+        token = claim_project(project=project, db=db, token=token)
         if index_file_exists:
             message = "Documentation uploaded and claimed successfully"
         else:

--- a/docat/docat/constants.py
+++ b/docat/docat/constants.py
@@ -1,0 +1,26 @@
+import os
+from typing import Optional
+
+ENV_GLOBAL_CLAIM_TOKEN = "DOCAT_GLOBAL_CLAIM_TOKEN"
+ENV_GLOBAL_CLAIM_SALT = "DOCAT_GLOBAL_CLAIM_SALT"
+
+
+def get_global_claim_token() -> Optional[str]:
+    """Returns the global claim token which can be defined by an environment variable.
+
+    Returns:
+        The optional global claim token or None.
+    """
+    return os.environ.get(ENV_GLOBAL_CLAIM_TOKEN, None)
+
+
+def get_global_claim_salt() -> Optional[bytes]:
+    """Returns the global claim salt which can be defined by an environment variable.
+
+    Returns:
+        The optional global claim salt or None.
+    """
+    global_claim_salt = os.environ.get(ENV_GLOBAL_CLAIM_SALT, None)
+    if global_claim_salt is not None:
+        return global_claim_salt.encode()
+    return None

--- a/docat/tests/test_upload.py
+++ b/docat/tests/test_upload.py
@@ -33,6 +33,24 @@ def test_successfully_upload_with_global_claim(client):
     assert True is status.valid
 
 
+def test_successfully_upload_with_header_token(client):
+    with patch("docat.app.remove_docs"):
+        response = client.post(
+            "/api/some-project/1.0.0",
+            files={"file": ("index.html", io.BytesIO(b"<h1>Hello World</h1>"), "plain/text")},
+            headers={"Docat-Api-Key": "1234"},
+        )
+        response_data = response.json()
+
+        assert response.status_code == 201
+        assert response_data["message"] == "Documentation uploaded and claimed successfully"
+        assert "1234" == response_data["token"]
+        assert (docat.DOCAT_UPLOAD_FOLDER / "some-project" / "1.0.0" / "index.html").exists()
+
+    status = check_token_for_project(db=docat.db, token="1234", project="some-project")
+    assert True is status.valid
+
+
 def test_successfully_override(client_with_claimed_project):
     with patch("docat.app.remove_docs") as remove_mock:
         response = client_with_claimed_project.post(


### PR DESCRIPTION
By declaring the environment variable(s) `DOCAT_GLOBAL_CLAIM_TOKEN` (and optionally `DOCAT_GLOBAL_CLAIM_SALT`), all projects can be automatically claimed with a previously defined token (and salt).

This resolves #618.