### PR TITLE
Allow configuration of MAX_UPLOAD_SIZE

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Same thing with `docatl`:
 docatl tag --host http://localhost:8000 PROJECT VERSION latest
 ```
 
-## Advanced `config.json`
+## Advanced Frontend `config.json`
 
 It is possible to configure some things after the fact.
 
@@ -101,3 +101,10 @@ It is possible to configure some things after the fact.
 Supported config options:
 
 - headerHTML
+
+## Advanced System Config
+
+Further proxy configurations can be done through the following environmental variables:
+| Varaiable | Default (Link to Definition) | Description |
+|---|---|---|
+| MAX_UPLOAD_SIZE | [100M](./Dockerfile) | Limits the size of individual archives posted to the API |

--- a/docat/docat/nginx/default
+++ b/docat/docat/nginx/default
@@ -18,7 +18,7 @@ server {
     }
 
     location /api {
-        client_max_body_size 100M;
+        client_max_body_size $MAX_UPLOAD_SIZE;
         proxy_pass http://python_backend;
     }
 


### PR DESCRIPTION
Allow the image users (server operators) to define their own limit for the Maximal Documentation size.

This approach implements a new Environmental Variable, which can be used to overwrite the default maximum post size of 100MB. It was proposed with the same default to be backwards compatible and simple to setup. 
With this change the operator can adapt the application better to their specific environment.