### PR TITLE
feat(web): allow to configure proxy port through env var

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,35 +1,38 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: '/',
-  plugins: [react()],
-  assetsInclude: ['**/*.md'],
-  server: {
-    port: 8080,
-    proxy: {
-      "/api": {
-	 target: "http://localhost:5000",
-	 changeOrigin: true,
-	 secure: false,
-      },
-      "/doc": {
-	target: "http://localhost:5000",
-	changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd())
+  return {
+    base: '/',
+    plugins: [react()],
+    assetsInclude: ['**/*.md'],
+    server: {
+      port: 8080,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:' + `${env.VITE_PROXY_PORT ?? '5000'}`,
+          changeOrigin: true,
+          secure: false
+        },
+        '/doc': {
+          target: 'http://localhost:' + `${env.VITE_PROXY_PORT ?? '5000'}`,
+          changeOrigin: true,
+          secure: false
+        }
       }
-    }
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    css: true,
-    reporters: ['verbose'],
-    coverage: {
-      reporter: ['text', 'json', 'html'],
-      include: ['src/**/*'],
-      exclude: [],
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      css: true,
+      reporters: ['verbose'],
+      coverage: {
+        reporter: ['text', 'json', 'html'],
+        include: ['src/**/*'],
+        exclude: []
+      }
     }
   }
 })


### PR DESCRIPTION
It is already possible to configure the backend port through environment variable (`PORT=XXXX poetry run python -m docat`). In such case, the web component must be able to configure accordingly.