### PR TITLE
Alphabetical projects ordering

### DIFF
--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -16,15 +16,17 @@ export default function ProjectList(props: Props): JSX.Element {
 
   return (
     <div className={styles['project-list']}>
-      {props.projects.map((project) => (
-        <Project
-          project={project}
-          key={project.name}
-          onFavoriteChanged={() => {
-            props.onFavoriteChanged()
-          }}
-        />
-      ))}
+      {props.projects
+        .sort((a, b) => (a.name > b.name ? 1 : -1))
+        .map((project) => (
+          <Project
+            project={project}
+            key={project.name}
+            onFavoriteChanged={() => {
+              props.onFavoriteChanged()
+            }}
+          />
+        ))}
     </div>
   )
 }


### PR DESCRIPTION
We have a bunch of projects, and they are currently displayed in the order they were pushed which makes it slightly painful to search for a specific one at glance without using the search bar.