### PR TITLE
fix(web): remove hash routes in documentation

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -48,10 +48,10 @@ docatl push docs.zip awesome-project 1.0.0 --host http://localhost:8000
 
 Any file type can be uploaded. To view an uploaded pdf, specify it's full path:
 
-`http://localhost:8000/#/awesome-project/1.0.0/my_awesome.pdf`
+`http://localhost:8000/awesome-project/1.0.0/my_awesome.pdf`
 
 You can also manually upload your documentation.
-A very simple web form can be found under [upload](#/upload).
+A very simple web form can be found under [upload](/upload).
 
 #### Tag documentation
 

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -99,7 +99,7 @@ export default function Home(): JSX.Element {
             <Tooltip title="Upload Documentation" placement="right" arrow>
               <IconButton
                 sx={{ marginLeft: 2, height: '46px', width: '46px', marginTop: '2px'}}
-                href="/#/upload"
+                href="/upload"
               >
                 <FileUpload></FileUpload>
               </IconButton>
@@ -108,7 +108,7 @@ export default function Home(): JSX.Element {
             <Tooltip title="Claim a Project" placement="right" arrow>
               <IconButton
                 sx={{ marginLeft: 2, height: '46px', width: '46px', marginTop: '2px'}}
-                href="/#/claim"
+                href="/claim"
               >
                 <Lock></Lock>
               </IconButton>
@@ -117,7 +117,7 @@ export default function Home(): JSX.Element {
             <Tooltip title="Delete a project version" placement="right" arrow>
               <IconButton
                 sx={{ marginLeft: 2, height: '46px', width: '46px', marginTop: '2px'}}
-                href="/#/delete"
+                href="/delete"
               >
                 <Delete></Delete>
               </IconButton>


### PR DESCRIPTION
This PR removes all remaining hash-based routes in the website. This also fixes the bug of `upload` link being incorrect in help page.